### PR TITLE
#22 [Feat] UserDefaults를 extension하여 스트레스, 보상 연산 프로퍼티 구현

### DIFF
--- a/donggle/donggle.xcodeproj/project.pbxproj
+++ b/donggle/donggle.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		31A38ABB27FEEB7600F4EAE8 /* GiftCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A38ABA27FEEB7600F4EAE8 /* GiftCheckView.swift */; };
+		918E3B5E2800350A0045DA4F /* SRdata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918E3B5D2800350A0045DA4F /* SRdata.swift */; };
 		91BF869B27FECD2300A95FA9 /* donggleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BF869A27FECD2300A95FA9 /* donggleApp.swift */; };
 		91BF869D27FECD2300A95FA9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BF869C27FECD2300A95FA9 /* ContentView.swift */; };
 		91BF869F27FECD2300A95FA9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 91BF869E27FECD2300A95FA9 /* Assets.xcassets */; };
@@ -33,6 +34,7 @@
 
 /* Begin PBXFileReference section */
 		31A38ABA27FEEB7600F4EAE8 /* GiftCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCheckView.swift; sourceTree = "<group>"; };
+		918E3B5D2800350A0045DA4F /* SRdata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRdata.swift; sourceTree = "<group>"; };
 		91BF869727FECD2300A95FA9 /* donggle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = donggle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		91BF869A27FECD2300A95FA9 /* donggleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = donggleApp.swift; sourceTree = "<group>"; };
 		91BF869C27FECD2300A95FA9 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -68,6 +70,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		918E3B5C280033BB0045DA4F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				918E3B5D2800350A0045DA4F /* SRdata.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		91BF868E27FECD2300A95FA9 = {
 			isa = PBXGroup;
 			children = (
@@ -87,6 +97,7 @@
 		91BF869927FECD2300A95FA9 /* donggle */ = {
 			isa = PBXGroup;
 			children = (
+				918E3B5C280033BB0045DA4F /* Model */,
 				F23139B727FEE0C700D4EB9F /* Views */,
 				91BF869A27FECD2300A95FA9 /* donggleApp.swift */,
 				CCD9C74227FED4EB00C21709 /* Tab bar Views */,
@@ -238,6 +249,7 @@
 				F23139C827FEE24300D4EB9F /* CustomTapView.swift in Sources */,
 				CCD9C74827FED51F00C21709 /* CalenderView.swift in Sources */,
 				F23139D327FEE2A100D4EB9F /* TimelineView.swift in Sources */,
+				918E3B5E2800350A0045DA4F /* SRdata.swift in Sources */,
 				91BF869B27FECD2300A95FA9 /* donggleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -367,6 +379,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"donggle/Preview Content\"";
+				DEVELOPMENT_TEAM = 54QH6LCWDM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -395,6 +408,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"donggle/Preview Content\"";
+				DEVELOPMENT_TEAM = 54QH6LCWDM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/donggle/donggle/Model/SRdata.swift
+++ b/donggle/donggle/Model/SRdata.swift
@@ -22,6 +22,7 @@ struct Reward : Codable{
     var content : String?
     var date : Date
     var category : String
+    var isEffective : Bool?
     var stressKey : UUID?
 }
 

--- a/donggle/donggle/Model/SRdata.swift
+++ b/donggle/donggle/Model/SRdata.swift
@@ -12,7 +12,7 @@ struct Stress : Codable{
     var index : Int
     var content : String?
     var date : Date
-    var category : String
+    var category : [String]
     var rewardKey : UUID?
 }
 
@@ -21,7 +21,7 @@ struct Reward : Codable{
     var title : String
     var content : String?
     var date : Date
-    var category : String
+    var category : [String]
     var isEffective : Bool?
     var stressKey : UUID?
 }

--- a/donggle/donggle/Model/SRdata.swift
+++ b/donggle/donggle/Model/SRdata.swift
@@ -1,0 +1,55 @@
+//
+//  SRdata.swift
+//  donggle
+//
+//  Created by Lee Myeonghwan on 2022/04/08.
+//
+
+import Foundation
+
+struct Stress : Codable{
+    var id : UUID
+    var index : Int
+    var content : String?
+    var date : Date
+    var category : String
+    var rewardKey : UUID?
+}
+
+struct Reward : Codable{
+    var id : UUID
+    var title : String
+    var content : String?
+    var date : Date
+    var category : String
+    var stressKey : UUID?
+}
+
+extension UserDefaults {
+    static var stressArray: [Stress]? {
+      get {
+          var stress: [Stress]?
+          if let data = UserDefaults.standard.value(forKey:"stressArray") as? Data {
+              stress = try? PropertyListDecoder().decode([Stress].self, from: data)
+          }
+          return stress ?? []
+      }
+      set {
+          UserDefaults.standard.set(try? PropertyListEncoder().encode(newValue), forKey:"stressArray")
+      }
+  }
+
+    
+    static var rewardArray: [Reward]? {
+        get {
+            var reward: [Reward]?
+            if let data = UserDefaults.standard.value(forKey:"rewardArray") as? Data {
+                reward = try? PropertyListDecoder().decode([Reward].self, from: data)
+            }
+            return reward ?? []
+        }
+        set {
+            UserDefaults.standard.set(try? PropertyListEncoder().encode(newValue), forKey:"rewardArray")
+        }
+    }
+}

--- a/donggle/donggle/Tab bar Views/CalenderView.swift
+++ b/donggle/donggle/Tab bar Views/CalenderView.swift
@@ -12,17 +12,17 @@ struct CalendarView: View {
     @State private var selectedDate = Date()
     
     static let dateFormat: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "YYYY.MM.dd"
-            return formatter
-        }()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYYY.MM.dd"
+        return formatter
+    }()
     
     static let dateFormatText: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "YYYY년 M월 d일"
-            return formatter
-        }()
-
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYYY년 M월 d일"
+        return formatter
+    }()
+    
     struct Reward {
         var id: Int
         var title: String
@@ -43,36 +43,36 @@ struct CalendarView: View {
         Reward(id : 6, title : "꿈틀거리기", description : "메로나 먹고싶어", date : "2022.04.12", category : "🪱", isEffective : nil, stressKey : 1 )]
     
     let columns = [
-            GridItem(.flexible()),
-            GridItem(.flexible()),
-            GridItem(.flexible())
-        ]
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+        GridItem(.flexible())
+    ]
     
     var body: some View {
         
-                NavigationView {
+        NavigationView {
             VStack {
-                        DatePicker("Selected Date",
-                                   selection: $selectedDate,
-                                   in : Date()...,
-                                displayedComponents: [.date]
-                            )
-                            .datePickerStyle(.graphical)
-                            .navigationBarTitle(Text("보상캘린더"))
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                                ToolbarItem(placement: ToolbarItemPlacement.navigationBarTrailing) {
-                                    Button(action: {
-                                                    
-                                    }) {
-                                            Image(systemName: "plus")
-                                    }
-                                }
+                DatePicker("Selected Date",
+                           selection: $selectedDate,
+                           in : Date()...,
+                           displayedComponents: [.date]
+                )
+                .datePickerStyle(.graphical)
+                .navigationBarTitle(Text("보상캘린더"))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: ToolbarItemPlacement.navigationBarTrailing) {
+                        Button(action: {
+                            
+                        }) {
+                            Image(systemName: "plus")
                         }
-
-                    Divider()
+                    }
+                }
                 
-                    Text("\(selectedDate, formatter: CalendarView.dateFormatText)")
+                Divider()
+                
+                Text("\(selectedDate, formatter: CalendarView.dateFormatText)")
                     .padding(10)
                     .font(.title)
                 
@@ -93,16 +93,16 @@ struct CalendarView: View {
                             
                             ForEach(currentInfo, id: \.self.id) { reward in
                                 
-                                    VStack{
-                                        Text(reward.category)
-                                            .font(Font.system(size: 50, design: .default))
-                                        Text(reward.title)
-                                        }.padding(20)
-                                        .frame(height: 160)
-                                        .overlay(
-                                                    RoundedRectangle(cornerRadius: 15)
-                                                    .stroke(lineWidth: 1)
-                                        )
+                                VStack{
+                                    Text(reward.category)
+                                        .font(Font.system(size: 50, design: .default))
+                                    Text(reward.title)
+                                }.padding(20)
+                                    .frame(height: 160)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 15)
+                                            .stroke(lineWidth: 1)
+                                    )
                                 
                             }.padding(10)
                         })

--- a/donggle/donggle/Views/ContentView.swift
+++ b/donggle/donggle/Views/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Foundation
 
 struct ContentView: View {
+    @State private var showModal = false
     var body: some View {
         Text("Hello world")
     }

--- a/donggle/donggle/Views/ContentView.swift
+++ b/donggle/donggle/Views/ContentView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+import Foundation
+
 struct ContentView: View {
     var body: some View {
         Text("Hello world")

--- a/donggle/donggle/Views/RecordView.swift
+++ b/donggle/donggle/Views/RecordView.swift
@@ -15,6 +15,7 @@ struct MultipleSelectionRow: View {
 }
 
 struct RecordView: View {
+    @Environment(\.dismiss) private var dismiss
     @State var sliderValue: Double = 50
     @State var sliderRGB: Double = 50
     @State var stressSelectionOn: Bool = false
@@ -28,11 +29,10 @@ struct RecordView: View {
     @State var rewardCategory: [String] = ["잠자기", "알콜", "쇼핑", "운동", "음식", "놀기"]
     @State private var rewardDate = Date()
     
-    
     var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 4)
     
     var body: some View {
-        VStack{
+        NavigationView{
             Form {
                 Section{
                     VStack{
@@ -111,12 +111,27 @@ struct RecordView: View {
                     }
                 }
             }
+            .navigationTitle(Text("기록하기"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar{
+                ToolbarItem(placement: .navigationBarLeading){
+                    Button(action:{
+                        dismiss()
+                    }){
+                        Text("취소")
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing){
+                    Button("추가"){
+                    }
+                }
+            }
         }
     }
 }
 
-struct RecordView_Previews: PreviewProvider {
-    static var previews: some View {
-        RecordView()
-    }
-}
+//struct RecordView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        RecordView()
+//    }
+//}


### PR DESCRIPTION
## 작업내용

Models 그룹에 SRdata 를 추가하여 스트레스, 보상 struct 데이터를 기록하고 불러올 수 있도록 만들었습니다.


## 사용법

import Foundation 후 연산 프로퍼티처럼 사용하면 됩니다!
ex)
스트레스 데이터 추가 후 저장:

```
var sArray : [Stress] = []
var stress1 = Stress(id: UUID(),index: 13, content: "사과 스트레스", date: Date(), category: "🍎", rewardKey: nil)
var stress2 = Stress(id: UUID(),index: 23, content: "불꽃 스트레스", date: Date(), category: "🔥", rewardKey: nil)
sArray.append(stress1)
sArray.append(stress2)
UserDefaluts.stressArray = sArray
```

스트레스 보상 불러오기:

```
let stressSet = UserDefaults.stressArray ?? []
print(stressSet)
print(stressSet[0].content ?? "")
print(stressSet[1].content ?? "")
//[donggle.Stress(id: 3E49C33A-56D1-4D6E-8E78-AF971FE6F723, index: 13, content: Optional("사과 스트레스"), date: 2022-04-08 10:01:09 +0000, category: "🍎", rewardKey: nil), donggle.Stress(id: DF7781E6-02C6-45CD-B87F-E8A9921F08C6, index: 23, content: Optional("불꽃 스트레스"), date: 2022-04-08 10:01:09 +0000, category: "🔥", rewardKey: nil)]      
//사과 스트레스.    
//불꽃 스트레스.       
```


예제 코드
-> https://www.notion.so/rriver2/a1cfcb9619d045ee8a750a27b158bf62?v=e8257524cc0942b8881b05a55f83ee45
UserDefaults 예제 코드 페이지에 코드를 올려놨으니 감이 안잡히면 Xcode내에서 예제코드를 만져보는 것을 추천드립니다. 물론 질문도 환영입니다.

## 리뷰 포인트

- UserDefaluts에 커스텀 오브젝트를 저장하기 위해 UserDefaluts를 extension하여 내부에서 encode decode하는 연산 프로퍼티를 만들었습니다. 

## 다음 작업
- [ ] 기록페이지에서 스트레스, 보상 데이터 추가

## References
- https://kyungmosung.github.io/2020/08/17/swift-userdefaults-customobject/  [Swift] UserDefaults: Custom Object(Model) 저장하기
- https://babbab2.tistory.com/119 연산 프로퍼티


