### PR TITLE
#24 [Feat] 기록 뷰에서 Userdefaluts로 데이터 추가 기능 구현

### DIFF
--- a/donggle/donggle.xcodeproj/project.pbxproj
+++ b/donggle/donggle.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		31A38ABB27FEEB7600F4EAE8 /* GiftCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A38ABA27FEEB7600F4EAE8 /* GiftCheckView.swift */; };
+		913108EE2801704C00C4BAB2 /* RecordTestingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 913108ED2801704C00C4BAB2 /* RecordTestingView.swift */; };
 		918E3B5E2800350A0045DA4F /* SRdata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918E3B5D2800350A0045DA4F /* SRdata.swift */; };
 		91BF869B27FECD2300A95FA9 /* donggleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BF869A27FECD2300A95FA9 /* donggleApp.swift */; };
 		91BF869D27FECD2300A95FA9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BF869C27FECD2300A95FA9 /* ContentView.swift */; };
@@ -34,6 +35,7 @@
 
 /* Begin PBXFileReference section */
 		31A38ABA27FEEB7600F4EAE8 /* GiftCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCheckView.swift; sourceTree = "<group>"; };
+		913108ED2801704C00C4BAB2 /* RecordTestingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordTestingView.swift; sourceTree = "<group>"; };
 		918E3B5D2800350A0045DA4F /* SRdata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRdata.swift; sourceTree = "<group>"; };
 		91BF869727FECD2300A95FA9 /* donggle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = donggle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		91BF869A27FECD2300A95FA9 /* donggleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = donggleApp.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				CCD9C74B27FED53C00C21709 /* TabBarView.swift */,
 				F23139D127FEE26800D4EB9F /* UpperTab */,
 				91BF86A827FED68400A95FA9 /* RecordView.swift */,
+				913108ED2801704C00C4BAB2 /* RecordTestingView.swift */,
 				F23139BA27FEE13700D4EB9F /* StressReportView.swift */,
 				F23139BC27FEE13900D4EB9F /* RewardReportView.swift */,
 				F23139BE27FEE13C00D4EB9F /* ProgressBar.swift */,
@@ -241,6 +244,7 @@
 				F23139B627FEE0A500D4EB9F /* ReportView.swift in Sources */,
 				CCD9C74C27FED53C00C21709 /* TabBarView.swift in Sources */,
 				F23139BD27FEE13900D4EB9F /* RewardReportView.swift in Sources */,
+				913108EE2801704C00C4BAB2 /* RecordTestingView.swift in Sources */,
 				E61F252B27FFC45D00D3A96C /* RewardCard2.swift in Sources */,
 				F23139CE27FEE24B00D4EB9F /* TabBarButton.swift in Sources */,
 				F23139CC27FEE24900D4EB9F /* EdgeBorder.swift in Sources */,

--- a/donggle/donggle/Model/SRdata.swift
+++ b/donggle/donggle/Model/SRdata.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Stress : Codable{
     var id : UUID
     var index : Int
-    var content : String?
+    var content : String
     var date : Date
     var category : [String]
     var rewardKey : UUID?
@@ -19,7 +19,7 @@ struct Stress : Codable{
 struct Reward : Codable{
     var id : UUID
     var title : String
-    var content : String?
+    var content : String
     var date : Date
     var category : [String]
     var isEffective : Bool?

--- a/donggle/donggle/Views/ContentView.swift
+++ b/donggle/donggle/Views/ContentView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import Foundation
 
 struct ContentView: View {
-    @State private var showModal = false
     var body: some View {
         Text("Hello world")
     }

--- a/donggle/donggle/Views/RecordTestingView.swift
+++ b/donggle/donggle/Views/RecordTestingView.swift
@@ -1,0 +1,46 @@
+//
+//  RecordTestingView.swift
+//  donggle
+//
+//  Created by Lee Myeonghwan on 2022/04/09.
+//
+
+import SwiftUI
+
+struct RecordTestingView: View {
+    @State private var showModal = false
+    @State var sliderValue : Double = UserDefaults.standard.double(forKey:"sliderValue")
+    @State var stressIndex : Int = UserDefaults.standard.integer(forKey:"stressIndex")
+    func resetDefaults() {
+        let defaults = UserDefaults.standard
+        let dictionary = defaults.dictionaryRepresentation()
+        dictionary.keys.forEach { key in
+            defaults.removeObject(forKey: key)
+        }
+    }
+    var body: some View {
+        VStack {
+            Button(action: {
+            self.showModal = true
+            }){
+                Image(systemName: "square.and.pencil")
+                    .imageScale(.large)
+            }
+            .sheet(isPresented: self.$showModal) {
+                RecordView(stressIndex: $stressIndex ,sliderValue: $sliderValue)
+            }
+            Text("스트레스 지수: \(stressIndex)")
+            Button(action: {
+                resetDefaults()
+            }){
+                Text("UserDefaults 리셋")
+            }
+        }
+    }
+}
+
+struct RecordTestingView_Previews: PreviewProvider {
+    static var previews: some View {
+        RecordTestingView()
+    }
+}

--- a/donggle/donggle/Views/RecordView.swift
+++ b/donggle/donggle/Views/RecordView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import Foundation
+
 
 struct MultipleSelectionRow: View {
     var title: String
@@ -16,13 +18,15 @@ struct MultipleSelectionRow: View {
 
 struct RecordView: View {
     @Environment(\.dismiss) private var dismiss
-    @State var sliderValue: Double = 50
+    @Binding var stressIndex: Int
+    @Binding var sliderValue : Double
     @State var sliderRGB: Double = 50
     @State var stressSelectionOn: Bool = false
     @State var rewardSelectionOn: Bool = false
     @State var rewardIsOn: Bool = false
     @State var stressDescription: String = "스트레스 내용"
     @State var rewardDescription: String = "보상 내용"
+    @State var rewardTitle: String = ""
     @State var selectedStress: [String] = []
     @State var selectedReward: [String] = []
     @State var stressCategory: [String] = ["직장", "날씨", "수면", "가족", "돈", "그냥"]
@@ -30,6 +34,41 @@ struct RecordView: View {
     @State private var rewardDate = Date()
     
     var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 4)
+    
+    func saveRecord(sliderValue: Double, stressDescription: String, selectedStress : [String], rewardIsOn : Bool, rewardTitle: String, rewardDescription : String, selectedReward : [String], rewardDate : Date){
+        if stressDescription.isEmpty || stressDescription == "스트레스 내용" && selectedStress.isEmpty && !rewardIsOn{
+    //    스트레스 수치만 조절
+            print("---스트레스 수치만 조절---")
+        }else if !rewardIsOn{
+        //    스트레스 기록만
+            var sArray : [Stress] = UserDefaults.stressArray ?? []
+            let stressInstance = Stress(id: UUID(), index: stressIndex, content: stressDescription, date: Date(), category: selectedStress, rewardKey: nil)
+            sArray.append(stressInstance)
+            UserDefaults.stressArray = sArray
+            print("---스트레스만 기록---")
+            print(sArray)
+            print("-----------------")
+        }else{
+        //    스트레스 + 보상 기록
+            let stressUUID = UUID()
+            let rewardUUID = UUID()
+            var sArray : [Stress] = UserDefaults.stressArray ?? []
+            let stressInstance = Stress(id: stressUUID, index: self.stressIndex, content: stressDescription, date: Date(), category: selectedStress, rewardKey: rewardUUID)
+            sArray.append(stressInstance)
+            UserDefaults.stressArray = sArray
+            
+            var rArray : [Reward] = UserDefaults.rewardArray ?? []
+            let rewardInstance = Reward(id: rewardUUID, title: rewardTitle, content: rewardDescription, date: rewardDate, category: selectedReward, isEffective: nil, stressKey: stressUUID)
+            rArray.append(rewardInstance)
+            UserDefaults.rewardArray = rArray
+            print("---스트레스와 보상 함께 기록---")
+            print(sArray)
+            print(rArray)
+            print("-----------------")
+        }
+    }
+
+    
     
     var body: some View {
         NavigationView{
@@ -42,7 +81,7 @@ struct RecordView: View {
                             .frame(width: 130.0, height: 120.0)
                         HStack{
                             Text("😄")
-                            Slider(value: $sliderValue, in: 0...100)
+                            Slider(value: $sliderValue, in: 0...100,step: 1.0)
                                 .onChange(of: sliderValue){
                                     (newValue) in
                                     sliderRGB = 100 - newValue
@@ -82,7 +121,7 @@ struct RecordView: View {
                         Text("보상 추가")
                     }
                     if rewardIsOn{
-                        TextField("보상 제목", text: /*@START_MENU_TOKEN@*//*@PLACEHOLDER=Value@*/.constant("")/*@END_MENU_TOKEN@*/)
+                        TextField("보상 제목", text: $rewardTitle)
                         TextEditor(text: $rewardDescription)
                             .foregroundColor(self.rewardDescription == "보상 내용" ? .gray : .primary)
                             .onTapGesture {
@@ -116,6 +155,7 @@ struct RecordView: View {
             .toolbar{
                 ToolbarItem(placement: .navigationBarLeading){
                     Button(action:{
+                        sliderValue = Double(stressIndex)
                         dismiss()
                     }){
                         Text("취소")
@@ -123,6 +163,11 @@ struct RecordView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing){
                     Button("추가"){
+                        stressIndex = Int(sliderValue)
+                        UserDefaults.standard.set(stressIndex, forKey: "stressIndex")
+                        UserDefaults.standard.set(sliderValue, forKey: "sliderValue")
+                        saveRecord(sliderValue: sliderValue, stressDescription: stressDescription, selectedStress: selectedStress, rewardIsOn: rewardIsOn, rewardTitle: rewardTitle, rewardDescription: rewardDescription, selectedReward: selectedReward, rewardDate: rewardDate)
+                        dismiss()
                     }
                 }
             }


### PR DESCRIPTION
## 작업내용

RecordView에서 데이터 입력 후 추가 버튼을 누르면 UserDefaults에 데이터를 추가하도록 만듬.

RecordTestingView를 만들어 RecordView의 기능을 테스팅할 수 있도록 만듬. (이곳에서 데이터 추가, 제거 하시면 됩니다)

Models 그룹에 SRdata content : String? -> content: String 으로 수정. 해당 프로퍼티는 nil값이 필요하지 않음.


## 리뷰 포인트

- 사용자 입력 데이터를 paramater로 받아 Userdefaluts에 저장하는 **func SaveRecord** 를 만들었습니다.
- RecordTestingView에서 RecordView의 기능을 테스팅할 수 있습니다.

![2022-04-09 17 48 44](https://user-images.githubusercontent.com/56781342/162564237-79c208b2-abfe-42b5-9a12-c7c46aca94ab.gif)



## 다음 작업
- [ ] [Feat] HomeView와 RecordView연결 (동글이 색깔, 스트레스 지수 변화 반영)
- [ ] [Feat] HomeView 하단 보상 카드 Userdefaluts 데이터 기반 표시
- [ ] [Refactor] 동글이 인터렉션

## References
https://hyerios.tistory.com/187 데이터 바인딩

