### PR TITLE
#37 [Refactor] 타임라인 카드 리스트 VGrid로 구현 방법 변경

### DIFF
--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -89,21 +89,20 @@ struct TimelineView: View {
                     
                     if (selectedView == 1){ //전체
                         ScrollView(showsIndicators: false) {
-                            VStack(alignment: .center){
+                            LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(stressInfo, id: \.self.id) { stress in
                                     StressCard(stressIndex:stress.index, stressName: stress.category, stressContent: stress.content)
                                 }
                                 ForEach(rewardInfo, id: \.self.id) { reward in
                                     GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
                                 }
-                                
                             }
                         }
                         .padding(.horizontal, 10.0)
                         
                     }else if (selectedView == 2){ //스트레스
                         ScrollView(showsIndicators: false) {
-                            VStack(alignment: .center){
+                            LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(stressInfo, id: \.self.id) { stress in
                                     StressCard(stressIndex:stress.index, stressName: stress.category, stressContent: stress.content)
                                 }
@@ -113,7 +112,7 @@ struct TimelineView: View {
                         
                     } else if (selectedView == 3){ //보상
                         ScrollView(showsIndicators: false) {
-                            VStack(alignment: .center){
+                            LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(rewardInfo, id: \.self.id) { reward in
                                     GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
                                 }

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -3,11 +3,57 @@
 import SwiftUI
 
 
-
 struct TimelineView: View {
     @State private var date = Date()
     @State private var showModal = false
     @State private var selectedView = 2
+    
+
+    //스트레스, 보상 데이터 임시 정의
+    
+    var date1 = Date()
+    
+    
+    struct Reward {
+        var id: Int
+        var title: String
+        var content: String
+        var date: Date
+        var category: String
+        var isEffective: Bool?
+        var stressKey: Int?
+        var type: Int //스트레스(0) or 보상(1) 데이터 체크
+        var icon: String //보상 카테고리 아이콘
+    }
+    
+    struct Stress {
+        var id : Int
+        var index : Int
+        var content : String
+        var date : Date
+        var category : String
+        var rewardKey : UUID?
+    }
+    
+    @State private var stressInfo : [Stress] = [
+        Stress(id: 0, index: 13, content: "사과 스트레스", date: Date(), category: "🍎", rewardKey: nil),
+        Stress(id: 1, index: 23, content: "불꽃 스트레스", date: Date(), category: "🔥", rewardKey: nil),
+        Stress(id: 2, index: 37, content: "일이 너무 많고 어렵다. 맨날 야근을 해야하는데 잠이 너무 부족하고 짜증난다. 직장 사람들과는 친하지도 않아서 자리가 불편하다.", date: Date(), category: "직장", rewardKey: nil),
+        Stress(id: 3, index: 47, content: "이사를 가기 너무 귀찮다", date: Date(), category: "일상", rewardKey: nil),
+        Stress(id: 4, index: 17, content: "잠이 너무 부족하다.. 잠이 필요하다. 내일도 아침에 일찍 일어나야하는데, 벌써 새벽 두 시가 넘었다. 주말에 잠을 몰아서 자야할 것 같다. 요즘 잠을 자지 못해서 머리가 잘 안 돌아가는 것 같고, 건강도 안 좋아지는 것 같다.", date: Date(), category: "수면", rewardKey: nil)
+    
+    ]
+    
+    @State private var rewardInfo : [Reward] = [
+        Reward(id : 0, title : "맥주 한 잔!", content : "오늘 요정들과 함께 뿌링클 치킨 사서 치맥하기!", date : Date(), category : "음주", isEffective : nil, stressKey : nil, type: 1, icon : "🍺" ),
+        Reward(id : 1, title : "맛난 식사", content : "메로나 먹고싶어", date : Date(), category : "음식", isEffective : nil, stressKey : 1, type: 1, icon : "🍔" ),
+        Reward(id : 2, title : "여행가기", content : "메로나 먹고싶어", date : Date(), category : "외출", isEffective : nil, stressKey : 1, type: 1, icon : "🚚" ),
+        Reward(id : 3, title : "운동하기", content : "메로나 먹고싶어", date : Date(), category : "운동", isEffective : nil, stressKey : 1, type: 1, icon : "⚽️" ),
+        Reward(id : 4, title : "잠자기", content : "메로나 먹고싶어", date : Date(), category : "수면", isEffective : nil, stressKey : 1, type: 1, icon : "💤" ),
+        Reward(id : 5, title : "흐느적거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🐙" ),
+        Reward(id : 6, title : "꿈틀거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🪱" )]
+
+    
     
     var body: some View {
 
@@ -31,23 +77,50 @@ struct TimelineView: View {
                         
                         Picker(selection: $selectedView, label: /*@START_MENU_TOKEN@*/Text("Picker")/*@END_MENU_TOKEN@*/) {
                             Text("전체").tag(1)
-                            Text("보상").tag(2)
-                            Text("스트레스").tag(3)
+                            Text("스트레스").tag(2)
+                            Text("보상").tag(3)
 
                         }
                         
                     }
                     .padding([.leading, .trailing])
+
                     
-//                    Spacer()
-                    
-                    
-                    if (selectedView == 2){
-                        GiftView()
-                    } else if (selectedView == 3){
-                        StressView()
+                    if (selectedView == 1){ //전체
+                        ScrollView(showsIndicators: false) {
+                            VStack(alignment: .center){
+                                ForEach(stressInfo, id: \.self.id) { stress in
+                                    StressCard(stressIndex:stress.index, stressName: stress.category, stressContent: stress.content)
+                                }
+                                ForEach(rewardInfo, id: \.self.id) { reward in
+                                    GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
+                                }
+                                
+                            }
+                        }
+                        .padding(.horizontal, 10.0)
+                        
+                    }else if (selectedView == 2){ //스트레스
+                        ScrollView(showsIndicators: false) {
+                            VStack(alignment: .center){
+                                ForEach(stressInfo, id: \.self.id) { stress in
+                                    StressCard(stressIndex:stress.index, stressName: stress.category, stressContent: stress.content)
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 10.0)
+                        
+                    } else if (selectedView == 3){ //보상
+                        ScrollView(showsIndicators: false) {
+                            VStack(alignment: .center){
+                                ForEach(rewardInfo, id: \.self.id) { reward in
+                                    GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 10.0)
                     } else {
-                        TotalView()
+                        Text("no page")
                     }
                     
                 }
@@ -57,121 +130,105 @@ struct TimelineView: View {
 }
 
 
-
-struct TotalView : View {
+struct GiftCard : View {
+    var giftIcon: String
+    var giftName: String
+    var giftTitle: String
+    var giftContent: String
     var body: some View {
-        Text("전체 타임라인")
-    }
-}
-
-
-struct GiftView : View {
-    var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .center){
-                ForEach(0..<10) { _ in
-                    VStack(spacing: 5.0){
-                        HStack{
-                            Text("7 목")
-                                .font(.title3)
-                                .fontWeight(.bold)
-                            Spacer()
-                        }
-                        .padding(/*@START_MENU_TOKEN@*/.leading, 10.0/*@END_MENU_TOKEN@*/)
-                        HStack(alignment: .center){
-                            VStack(alignment: .center){
-                                Text("🍺")
-                                    .font(Font.system(size: 50, design: .default))
-                                Text("음주")
-                                    .fontWeight(.bold)
-                            }.padding(10.0)
-                                .frame(width: 80)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 15)
-                                .stroke(lineWidth: 1)
-                            )
-                            
-                            Spacer()
-                            VStack(alignment: .leading){
-                                Text("맥주 한 잔!")
-                                    .fontWeight(.bold)
-                                Divider()
-                                Text("오늘 요정들과 함께 뿌링클 치킨 사서 치맥하기!")
-                            }
-                        }
-                    }
-                }
-//                .frame(height: 140.0)
-                .padding(.all, 5.0)
-                .background(RoundedRectangle(cornerRadius: 15)
-                    .foregroundColor(/*@START_MENU_TOKEN@*//*@PLACEHOLDER=View@*/Color(hue: 1.0, saturation: 0.0, brightness: 0.926)/*@END_MENU_TOKEN@*/)
+        VStack(spacing: 5.0){
+            Text("7 목")
+                .font(.title3)
+                .fontWeight(.bold)
+                .padding(.leading, 5.0)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            
+            HStack(alignment: .center){
+                VStack(alignment: .center){
+                    Text(giftIcon)
+                        .font(Font.system(size: 50, design: .default))
+                    Text(giftName)
+                        .fontWeight(.bold)
+                }.padding(10.0)
+                    .frame(width: 80)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 15)
+                    .stroke(lineWidth: 1)
                 )
+                
+                Spacer()
+                VStack(alignment: .leading){
+                    Text(giftTitle)
+                        .fontWeight(.bold)
+                    Divider()
+                    Text(giftContent)
+                    Spacer()
+                }
             }
         }
-        .padding(.horizontal, 10.0)
+        .padding(.all, 5.0)
+        .background(RoundedRectangle(cornerRadius: 15)
+            .foregroundColor(/*@START_MENU_TOKEN@*//*@PLACEHOLDER=View@*/Color(hue: 1.0, saturation: 0.0, brightness: 0.926)/*@END_MENU_TOKEN@*/)
+        )
     }
+
 }
 
 
-struct StressView : View {
+struct StressCard : View {
+    var stressIndex: Int
+    var stressName: String
+    var stressContent: String
     var body: some View {
-        ScrollView(showsIndicators: false) {
-            VStack(alignment: .center){
-                ForEach(0..<10) { _ in
-                    VStack(spacing: 5.0){
-                        HStack{
-                            Text("7 목")
-                                .font(.title3)
-                                .fontWeight(.bold)
-                            Spacer()
-                        }
-                        .padding(/*@START_MENU_TOKEN@*/.leading, 10.0/*@END_MENU_TOKEN@*/)
-                        HStack(alignment: .center){
-                            VStack(alignment: .center){
-                                Circle()
-                                    .fill(Color.gray)
-                                Text("37%")
-                            }.padding(10.0)
-                                .frame(width: 80)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 15)
-                                .stroke(lineWidth: 0)
-                            )
-                            
-                            Spacer()
-                            VStack(alignment: .leading, spacing: 3.0){
-                                HStack{
-                                    Text("스트레스")
-                                        .padding(.horizontal, 5.0)
-                                        .foregroundColor(.white)
-                                    .background(RoundedRectangle(cornerRadius: 15)
-                                        .foregroundColor(.gray)
-                                    )
-                                    Text("직장")
-                                }
+        VStack(spacing: 5.0){
+            Text("7 목")
+                .font(.title3)
+                .fontWeight(.bold)
+                .padding(.leading, 5.0)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            
+            HStack(alignment: .center){
+                VStack(alignment: .center){
+                    Circle()
+                        .fill(Color.gray)
+                    Text(String(stressIndex))
+                    Spacer()
+                }.padding(10.0)
+                    .frame(width: 80, height: 100)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 15)
+                    .stroke(lineWidth: 0)
+                )
+                
+//                Spacer()
+                VStack(alignment: .leading, spacing: 3.0){
+                    HStack{
+                        Text("스트레스")
+                            .padding(.horizontal, 5.0)
+                            .foregroundColor(.white)
+                        .background(RoundedRectangle(cornerRadius: 15)
+                            .foregroundColor(.gray)
+                        )
+                        Text(stressName)
+                        Spacer()
+                    }
 //                                Divider()
-                                Text("일이 너무 많고 어렵다. 맨날 야근을 해야하는데 잠이 너무 부족하고 짜증난다. 직장 사람들과는 친하지도 않아서 자리가 불편하다.")
-                                    .font(.body)
-                            }
-                        }
-                    }
+                    Text(stressContent)
+                        .font(.body)
+                    Spacer()
                 }
-//                .frame(height: 140.0)
-                .padding(.all, 5.0)
-                .background(RoundedRectangle(cornerRadius: 15)
-                    .foregroundColor(/*@START_MENU_TOKEN@*//*@PLACEHOLDER=View@*/Color(hue: 1.0, saturation: 0.0, brightness: 0.926)/*@END_MENU_TOKEN@*/)
-                )
             }
         }
-        .padding(.horizontal, 10.0)
+        .padding(.all, 5.0)
+        .background(RoundedRectangle(cornerRadius: 15)
+            .foregroundColor(/*@START_MENU_TOKEN@*//*@PLACEHOLDER=View@*/Color(hue: 1.0, saturation: 0.0, brightness: 0.926)/*@END_MENU_TOKEN@*/)
+        )
+        
+        
     }
+
 }
 
-
-
-
-
-        
 
 
 struct TimelineView_Previews: PreviewProvider {

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -14,7 +14,7 @@ struct TimelineView: View {
     var date1 = Date()
     
     
-    struct Reward {
+    struct Reward2 {
         var id: Int
         var title: String
         var content: String
@@ -26,7 +26,7 @@ struct TimelineView: View {
         var icon: String //보상 카테고리 아이콘
     }
     
-    struct Stress {
+    struct Stress2 {
         var id : Int
         var index : Int
         var content : String
@@ -35,28 +35,29 @@ struct TimelineView: View {
         var rewardKey : UUID?
     }
     
-    @State private var stressInfo : [Stress] = [
-        Stress(id: 0, index: 13, content: "사과 스트레스", date: Date(), category: "🍎", rewardKey: nil),
-        Stress(id: 1, index: 23, content: "불꽃 스트레스", date: Date(), category: "🔥", rewardKey: nil),
-        Stress(id: 2, index: 37, content: "일이 너무 많고 어렵다. 맨날 야근을 해야하는데 잠이 너무 부족하고 짜증난다. 직장 사람들과는 친하지도 않아서 자리가 불편하다.", date: Date(), category: "직장", rewardKey: nil),
-        Stress(id: 3, index: 47, content: "이사를 가기 너무 귀찮다", date: Date(), category: "일상", rewardKey: nil),
-        Stress(id: 4, index: 17, content: "잠이 너무 부족하다.. 잠이 필요하다. 내일도 아침에 일찍 일어나야하는데, 벌써 새벽 두 시가 넘었다. 주말에 잠을 몰아서 자야할 것 같다. 요즘 잠을 자지 못해서 머리가 잘 안 돌아가는 것 같고, 건강도 안 좋아지는 것 같다.", date: Date(), category: "수면", rewardKey: nil)
+    @State private var stressInfo : [Stress2] = [
+        Stress2(id: 0, index: 13, content: "사과 스트레스", date: Date(), category: "🍎", rewardKey: nil),
+        Stress2(id: 1, index: 23, content: "불꽃 스트레스", date: Date(), category: "🔥", rewardKey: nil),
+        Stress2(id: 2, index: 37, content: "일이 너무 많고 어렵다. 맨날 야근을 해야하는데 잠이 너무 부족하고 짜증난다. 직장 사람들과는 친하지도 않아서 자리가 불편하다.", date: Date(), category: "직장", rewardKey: nil),
+        Stress2(id: 3, index: 47, content: "이사를 가기 너무 귀찮다", date: Date(), category: "일상", rewardKey: nil),
+        Stress2(id: 4, index: 17, content: "잠이 너무 부족하다.. 잠이 필요하다. 내일도 아침에 일찍 일어나야하는데, 벌써 새벽 두 시가 넘었다. 주말에 잠을 몰아서 자야할 것 같다. 요즘 잠을 자지 못해서 머리가 잘 안 돌아가는 것 같고, 건강도 안 좋아지는 것 같다.", date: Date(), category: "수면", rewardKey: nil)
     
     ]
     
-    @State private var rewardInfo : [Reward] = [
-        Reward(id : 0, title : "맥주 한 잔!", content : "오늘 요정들과 함께 뿌링클 치킨 사서 치맥하기!", date : Date(), category : "음주", isEffective : nil, stressKey : nil, type: 1, icon : "🍺" ),
-        Reward(id : 1, title : "맛난 식사", content : "메로나 먹고싶어", date : Date(), category : "음식", isEffective : nil, stressKey : 1, type: 1, icon : "🍔" ),
-        Reward(id : 2, title : "여행가기", content : "메로나 먹고싶어", date : Date(), category : "외출", isEffective : nil, stressKey : 1, type: 1, icon : "🚚" ),
-        Reward(id : 3, title : "운동하기", content : "메로나 먹고싶어", date : Date(), category : "운동", isEffective : nil, stressKey : 1, type: 1, icon : "⚽️" ),
-        Reward(id : 4, title : "잠자기", content : "메로나 먹고싶어", date : Date(), category : "수면", isEffective : nil, stressKey : 1, type: 1, icon : "💤" ),
-        Reward(id : 5, title : "흐느적거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🐙" ),
-        Reward(id : 6, title : "꿈틀거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🪱" )]
+    @State private var rewardInfo : [Reward2] = [
+        Reward2(id : 0, title : "맥주 한 잔!", content : "오늘 요정들과 함께 뿌링클 치킨 사서 치맥하기!", date : Date(), category : "음주", isEffective : nil, stressKey : nil, type: 1, icon : "🍺" ),
+        Reward2(id : 1, title : "맛난 식사", content : "메로나 먹고싶어", date : Date(), category : "음식", isEffective : nil, stressKey : 1, type: 1, icon : "🍔" ),
+        Reward2(id : 2, title : "여행가기", content : "메로나 먹고싶어", date : Date(), category : "외출", isEffective : nil, stressKey : 1, type: 1, icon : "🚚" ),
+        Reward2(id : 3, title : "운동하기", content : "메로나 먹고싶어", date : Date(), category : "운동", isEffective : nil, stressKey : 1, type: 1, icon : "⚽️" ),
+        Reward2(id : 4, title : "잠자기", content : "메로나 먹고싶어", date : Date(), category : "수면", isEffective : nil, stressKey : 1, type: 1, icon : "💤" ),
+        Reward2(id : 5, title : "흐느적거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🐙" ),
+        Reward2(id : 6, title : "꿈틀거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🪱" )]
+
 
     
     
     var body: some View {
-
+        
                 VStack{
                     HStack{
                         
@@ -124,6 +125,7 @@ struct TimelineView: View {
                     }
                     
                 }
+                .navigationBarTitle("타임라인", displayMode: .inline)
                     
         }
     


### PR DESCRIPTION


https://user-images.githubusercontent.com/67336936/162596987-113071eb-93ed-4e6c-a1e2-c53718376dae.mov


## 작업내용
#### VGrid 외에 이슈 생성 이전 작업한 내용 포함합니다.
- 타임라인 카드 리스트 VGrid로 구현 방법 변경
- stress card와 reward card의 뷰 분리
- reward, stress 임시 데이터 만들어 카드에 적용 (만들어주신 데이터 구조와 다른 부분이 조금 있는데, 추후에 user defaults 활용하면서 수정하겠습니다)
- 네비게이션 바 타이틀 생성 & 네비게이션 바와 컨텐츠 사이 space 없애기
- 내용에 따라 카드 내용 배치 달라지지 않도록 조정

##  리뷰포인트
- 리팩토링 중심으로 진행해서 표시되는 데이터가 달라진 것&네비게이션 바 말고는 크게 달라진 부분은 없습니다.

## 다음으로 진행될 작업
- user defaults 데이터 사용
- 전체 타임라인 구현
- Date 정보 사용해 카드에 날짜 표시
- 디자인 변경

## 질문
- stress card와 reward card view 분리해서 해당 view 활용해 '보상' '스트레스' 타임라인 만드는 방식으로 구현했는데, 더 좋은 방법이 있다면 마음껏 제안해주세요!

## References
