### PR TITLE
#47 [Feat] 타임라인 user Defaults 데이터 사용하여 구현

### DIFF
--- a/donggle/donggle.xcodeproj/xcshareddata/xcschemes/donggle.xcscheme
+++ b/donggle/donggle.xcodeproj/xcshareddata/xcschemes/donggle.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "91BF869627FECD2300A95FA9"
+               BuildableName = "donggle.app"
+               BlueprintName = "donggle"
+               ReferencedContainer = "container:donggle.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "91BF869627FECD2300A95FA9"
+            BuildableName = "donggle.app"
+            BlueprintName = "donggle"
+            ReferencedContainer = "container:donggle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "91BF869627FECD2300A95FA9"
+            BuildableName = "donggle.app"
+            BlueprintName = "donggle"
+            ReferencedContainer = "container:donggle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -13,14 +13,11 @@ struct TimelineView: View {
     
     var date1 = Date()
     
-    
-    
     let stressSet = UserDefaults.stressArray ?? []
     let rewardSet = UserDefaults.rewardArray ?? []
 
     
     var body: some View {
-        
         
                 VStack{
                     
@@ -56,10 +53,10 @@ struct TimelineView: View {
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(stressSet, id: \.self.id) { stress in
-                                    stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
+                                    stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category), stressDate: dateToString(dateInfo: stress.date))
                                 }
                                 ForEach(rewardSet, id: \.self.id) { reward in
-                                    RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content)
+                                    RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content, rewardDate: dateToString(dateInfo: reward.date))
                                 }
                             }
                         }
@@ -69,7 +66,7 @@ struct TimelineView: View {
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(stressSet, id: \.self.id) { stress in
-                                    stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
+                                    stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category), stressDate: dateToString(dateInfo: stress.date))
                                 }
                             }
                         }
@@ -79,7 +76,7 @@ struct TimelineView: View {
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(rewardSet, id: \.self.id) { reward in
-                                    RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content)
+                                    RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content, rewardDate: dateToString(dateInfo: reward.date))
                                 }
                             }
                         }
@@ -101,9 +98,10 @@ struct RewardTimeCard : View {
     var rewardName: String
     var rewardTitle: String
     var rewardContent: String
+    var rewardDate: String
     var body: some View {
         VStack(spacing: 5.0){
-            Text("7 목")
+            Text(rewardDate)
                 .font(.title3)
                 .fontWeight(.bold)
                 .padding(.leading, 5.0)
@@ -145,10 +143,11 @@ struct stressTimeCard : View {
     var stressIndex: Int
     var stressContent: String
     var stressCateList: String
+    var stressDate: String
         
     var body: some View {
         VStack(spacing: 5.0){
-            Text("7 목")
+            Text(stressDate)
                 .font(.title3)
                 .fontWeight(.bold)
                 .padding(.leading, 5.0)
@@ -215,6 +214,17 @@ func getStressCateList(stressCategory : [String]) -> String {
     stressCateList = stressCateArr.joined(separator: ", ")
     
     return stressCateList
+}
+
+func dateToString(dateInfo : Date) -> String {
+    
+    var dateString : String
+    
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy.MM.dd"
+    dateString = dateFormatter.string(from: dateInfo)
+    
+    return dateString
 }
 
 

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -14,29 +14,9 @@ struct TimelineView: View {
     var date1 = Date()
     
     
-    struct Reward2 {
-        var id: Int
-        var title: String
-        var content: String
-        var date: Date
-        var category: String
-        var isEffective: Bool?
-        var stressKey: Int?
-        var type: Int //스트레스(0) or 보상(1) 데이터 체크
-        var icon: String //보상 카테고리 아이콘
-    }
-
-    
-    @State private var rewardInfo : [Reward2] = [
-        Reward2(id : 0, title : "맥주 한 잔!", content : "오늘 요정들과 함께 뿌링클 치킨 사서 치맥하기!", date : Date(), category : "음주", isEffective : nil, stressKey : nil, type: 1, icon : "🍺" ),
-        Reward2(id : 1, title : "맛난 식사", content : "메로나 먹고싶어", date : Date(), category : "음식", isEffective : nil, stressKey : 1, type: 1, icon : "🍔" ),
-        Reward2(id : 2, title : "여행가기", content : "메로나 먹고싶어", date : Date(), category : "외출", isEffective : nil, stressKey : 1, type: 1, icon : "🚚" ),
-        Reward2(id : 3, title : "운동하기", content : "메로나 먹고싶어", date : Date(), category : "운동", isEffective : nil, stressKey : 1, type: 1, icon : "⚽️" ),
-        Reward2(id : 4, title : "잠자기", content : "메로나 먹고싶어", date : Date(), category : "수면", isEffective : nil, stressKey : 1, type: 1, icon : "💤" ),
-        Reward2(id : 5, title : "흐느적거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🐙" ),
-        Reward2(id : 6, title : "꿈틀거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🪱" )]
     
     let stressSet = UserDefaults.stressArray ?? []
+    let rewardSet = UserDefaults.rewardArray ?? []
 
     
     var body: some View {
@@ -78,8 +58,8 @@ struct TimelineView: View {
                                 ForEach(stressSet, id: \.self.id) { stress in
                                     StressCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
                                 }
-                                ForEach(rewardInfo, id: \.self.id) { reward in
-                                    GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
+                                ForEach(rewardSet, id: \.self.id) { reward in
+                                    GiftCard(giftIcon: "🍺", giftName: reward.category[0], giftTitle: reward.title, giftContent: reward.content)
                                 }
                             }
                         }
@@ -98,8 +78,8 @@ struct TimelineView: View {
                     } else if (selectedView == 3){ //보상
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
-                                ForEach(rewardInfo, id: \.self.id) { reward in
-                                    GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
+                                ForEach(rewardSet, id: \.self.id) { reward in
+                                    GiftCard(giftIcon: "🍺", giftName: reward.category[0], giftTitle: reward.title, giftContent: reward.content)
                                 }
                             }
                         }

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -25,24 +25,7 @@ struct TimelineView: View {
         var type: Int //스트레스(0) or 보상(1) 데이터 체크
         var icon: String //보상 카테고리 아이콘
     }
-    
-    struct Stress2 {
-        var id : Int
-        var index : Int
-        var content : String
-        var date : Date
-        var category : String
-        var rewardKey : UUID?
-    }
-    
-    @State private var stressInfo : [Stress2] = [
-        Stress2(id: 0, index: 13, content: "사과 스트레스", date: Date(), category: "🍎", rewardKey: nil),
-        Stress2(id: 1, index: 23, content: "불꽃 스트레스", date: Date(), category: "🔥", rewardKey: nil),
-        Stress2(id: 2, index: 37, content: "일이 너무 많고 어렵다. 맨날 야근을 해야하는데 잠이 너무 부족하고 짜증난다. 직장 사람들과는 친하지도 않아서 자리가 불편하다.", date: Date(), category: "직장", rewardKey: nil),
-        Stress2(id: 3, index: 47, content: "이사를 가기 너무 귀찮다", date: Date(), category: "일상", rewardKey: nil),
-        Stress2(id: 4, index: 17, content: "잠이 너무 부족하다.. 잠이 필요하다. 내일도 아침에 일찍 일어나야하는데, 벌써 새벽 두 시가 넘었다. 주말에 잠을 몰아서 자야할 것 같다. 요즘 잠을 자지 못해서 머리가 잘 안 돌아가는 것 같고, 건강도 안 좋아지는 것 같다.", date: Date(), category: "수면", rewardKey: nil)
-    
-    ]
+
     
     @State private var rewardInfo : [Reward2] = [
         Reward2(id : 0, title : "맥주 한 잔!", content : "오늘 요정들과 함께 뿌링클 치킨 사서 치맥하기!", date : Date(), category : "음주", isEffective : nil, stressKey : nil, type: 1, icon : "🍺" ),
@@ -52,13 +35,15 @@ struct TimelineView: View {
         Reward2(id : 4, title : "잠자기", content : "메로나 먹고싶어", date : Date(), category : "수면", isEffective : nil, stressKey : 1, type: 1, icon : "💤" ),
         Reward2(id : 5, title : "흐느적거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🐙" ),
         Reward2(id : 6, title : "꿈틀거리기", content : "메로나 먹고싶어", date : Date(), category : "휴식", isEffective : nil, stressKey : 1, type: 1, icon : "🪱" )]
-
-
     
+    let stressSet = UserDefaults.stressArray ?? []
+
     
     var body: some View {
         
+        
                 VStack{
+                    
                     HStack{
                         
                         Button(action: {
@@ -90,8 +75,8 @@ struct TimelineView: View {
                     if (selectedView == 1){ //전체
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
-                                ForEach(stressInfo, id: \.self.id) { stress in
-                                    StressCard(stressIndex:stress.index, stressName: stress.category, stressContent: stress.content)
+                                ForEach(stressSet, id: \.self.id) { stress in
+                                    StressCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
                                 }
                                 ForEach(rewardInfo, id: \.self.id) { reward in
                                     GiftCard(giftIcon: reward.icon, giftName: reward.category, giftTitle: reward.title, giftContent: reward.content)
@@ -103,8 +88,8 @@ struct TimelineView: View {
                     }else if (selectedView == 2){ //스트레스
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
-                                ForEach(stressInfo, id: \.self.id) { stress in
-                                    StressCard(stressIndex:stress.index, stressName: stress.category, stressContent: stress.content)
+                                ForEach(stressSet, id: \.self.id) { stress in
+                                    StressCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
                                 }
                             }
                         }
@@ -178,8 +163,9 @@ struct GiftCard : View {
 
 struct StressCard : View {
     var stressIndex: Int
-    var stressName: String
     var stressContent: String
+    var stressCateList: String
+        
     var body: some View {
         VStack(spacing: 5.0){
             Text("7 목")
@@ -201,19 +187,25 @@ struct StressCard : View {
                     .stroke(lineWidth: 0)
                 )
                 
-//                Spacer()
                 VStack(alignment: .leading, spacing: 3.0){
-                    HStack{
-                        Text("스트레스")
-                            .padding(.horizontal, 5.0)
-                            .foregroundColor(.white)
-                        .background(RoundedRectangle(cornerRadius: 15)
-                            .foregroundColor(.gray)
-                        )
-                        Text(stressName)
+                    HStack(alignment: .top){ //카테고리 두 줄 이상일 때 위쪽으로 정렬되도록
+                        
+                            Text("스트레스")
+                                .padding(.horizontal, 5.0)
+                                .foregroundColor(.white)
+                            .background(RoundedRectangle(cornerRadius: 15)
+                                .foregroundColor(.gray)
+                            )
+                            
+//                        ForEach(stressCategory, id:\.self){ category in
+//                            Text(category)
+//                            stressCateList.append(category)
+                            
+//                        }
+                        Text(stressCateList)
                         Spacer()
                     }
-//                                Divider()
+
                     Text(stressContent)
                         .font(.body)
                     Spacer()
@@ -230,6 +222,20 @@ struct StressCard : View {
 
 }
 
+//여러개의 카테고리가 ","로 구분되어 나열된 string 만들기
+func getStressCateList(stressCategory : [String]) -> String {
+    
+    var stressCateArr : [String] = []
+    var stressCateList : String
+    
+    for category in stressCategory{
+        stressCateArr.append(category)
+    }
+    
+    stressCateList = stressCateArr.joined(separator: ", ")
+    
+    return stressCateList
+}
 
 
 struct TimelineView_Previews: PreviewProvider {

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -56,10 +56,10 @@ struct TimelineView: View {
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(stressSet, id: \.self.id) { stress in
-                                    StressCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
+                                    stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
                                 }
                                 ForEach(rewardSet, id: \.self.id) { reward in
-                                    GiftCard(giftIcon: "🍺", giftName: reward.category[0], giftTitle: reward.title, giftContent: reward.content)
+                                    RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content)
                                 }
                             }
                         }
@@ -69,7 +69,7 @@ struct TimelineView: View {
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(stressSet, id: \.self.id) { stress in
-                                    StressCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
+                                    stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category))
                                 }
                             }
                         }
@@ -79,7 +79,7 @@ struct TimelineView: View {
                         ScrollView(showsIndicators: false) {
                             LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
                                 ForEach(rewardSet, id: \.self.id) { reward in
-                                    GiftCard(giftIcon: "🍺", giftName: reward.category[0], giftTitle: reward.title, giftContent: reward.content)
+                                    RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content)
                                 }
                             }
                         }
@@ -96,11 +96,11 @@ struct TimelineView: View {
 }
 
 
-struct GiftCard : View {
-    var giftIcon: String
-    var giftName: String
-    var giftTitle: String
-    var giftContent: String
+struct RewardTimeCard : View {
+    var rewardIcon: String
+    var rewardName: String
+    var rewardTitle: String
+    var rewardContent: String
     var body: some View {
         VStack(spacing: 5.0){
             Text("7 목")
@@ -111,9 +111,9 @@ struct GiftCard : View {
             
             HStack(alignment: .center){
                 VStack(alignment: .center){
-                    Text(giftIcon)
+                    Text(rewardIcon)
                         .font(Font.system(size: 50, design: .default))
-                    Text(giftName)
+                    Text(rewardName)
                         .fontWeight(.bold)
                 }.padding(10.0)
                     .frame(width: 80)
@@ -124,10 +124,10 @@ struct GiftCard : View {
                 
                 Spacer()
                 VStack(alignment: .leading){
-                    Text(giftTitle)
+                    Text(rewardTitle)
                         .fontWeight(.bold)
                     Divider()
-                    Text(giftContent)
+                    Text(rewardContent)
                     Spacer()
                 }
             }
@@ -141,7 +141,7 @@ struct GiftCard : View {
 }
 
 
-struct StressCard : View {
+struct stressTimeCard : View {
     var stressIndex: Int
     var stressContent: String
     var stressCateList: String


### PR DESCRIPTION

https://user-images.githubusercontent.com/67336936/162631170-158308cd-07a3-4517-b885-6e7d5bdb0d66.mov



## 작업내용
UserDefaults 데이터가 타임라인 페이지에 나타나도록 구현
gift -> reward로 변수명 변경, 중복 방지 위해 카드 뷰 이름 변경

##  리뷰포인트
- UserDefaults 데이터가 타임라인 페이지에 나타나도록 구현하였고, 카드 내의 (이모티콘 제외) 모든 정보는 UserDefaults에 미리 추가한 데이터입니다.
  - date -> string 변환은 dateToString 함수 만들어 사용
- 스트레스에서 여러개의 카테고리가 존재할 경우, "직장, 일상, 수면" 과 같이 하나의 문자열로 나열되어 보여지도록 구현했습니다.
  - 문자열 만들기는 getStressCateList 함수 만들어 사용

## 다음으로 진행될 작업

- [ ] 디자인 변경
- [ ] 전체 타임라인 구현
- [ ] 월별 스트레스/보상 정보 가져오는 메소드 구현 후 월 선택에 따라 내용 달라지게 구현

## 질문
데이터에 카테고리의 이모티콘 필드는 정의되어있지 않던데, 이모티콘 데이터는 어디서 가져오면 될까요?

## References

* resolved: #47 
