### PR TITLE
#34 [Feat] 네비게이션 바 추가 및 액션시트 추가

### DIFF
--- a/donggle/donggle/Views/CardDetailView.swift
+++ b/donggle/donggle/Views/CardDetailView.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 struct CardDetailView: View {
     
+    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    
+    @State var showingSheet = false
+    
     @State var backDegree = 0.0
     @State var frontDegree = -90.0
     @State var isFlipped = false
@@ -39,15 +43,32 @@ struct CardDetailView: View {
     @State var Evaluation = false
     
     var body: some View {
+        NavigationView{
         ZStack{
             Color(red: 249/255, green: 249/255, blue: 249/255).ignoresSafeArea()
-            VStack{
-                Text("보상 상세")
-                    .font(.system(size: 17, weight: .semibold))
-                    .multilineTextAlignment(.center)
-                    .padding(.top, 12.0)
-                Spacer()
-            }
+            /*
+            ZStack{
+                VStack{
+                    HStack{
+                        Image(systemName: "chevron.left")
+                            .padding(.leading, 24)
+                            .padding(.top, 12.0)
+                        Spacer()
+                        Image(systemName: "ellipsis")
+                            .padding(.trailing, 24)
+                            .padding(.top, 12.0)
+                    }
+                    Spacer()
+                }
+                VStack{
+                    Text("보상 상세")
+                        .font(.system(size: 17, weight: .semibold))
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 12.0)
+                    Spacer()
+                }
+            } */
+            
             VStack{
                 ZStack{
                     DetailCardFront(width: width, height: height, degree: $backDegree)
@@ -72,6 +93,34 @@ struct CardDetailView: View {
                     GiftCheckView()
                 }
             }
+        }
+        .navigationBarTitle("보상 상세", displayMode: .inline)
+        .navigationBarItems(leading: Button(action : {
+            self.mode.wrappedValue.dismiss()
+        }){
+            Image(systemName: "chevron.left")
+                .foregroundColor(Color.black)
+                .padding(8)
+        }, trailing:
+                Button(action: {
+                    self.showingSheet = true
+                }, label: {
+                    Image(systemName: "ellipsis")
+                        .padding(8)
+                        .foregroundColor(Color.black)
+        })
+                    .confirmationDialog("", isPresented: $showingSheet, titleVisibility: .hidden){
+                        Button("보상 수정"){
+
+                        }
+                        Button("보상 삭제", role: .destructive){
+                            
+                        }
+                        Button("취소", role: .cancel){
+                            
+                        }
+                    }
+        )
         }
     }
 }

--- a/donggle/donggle/Views/DetailCard/DetailCardBack.swift
+++ b/donggle/donggle/Views/DetailCard/DetailCardBack.swift
@@ -17,17 +17,10 @@ struct DetailCardBack: View {
 
         ZStack(){
             VStack{
-                ZStack(){
-                    Text("2022.04.03")
-                        .font(.system(size: 15, weight: .regular))
-                        .multilineTextAlignment(.center)
-                    HStack(){
-                        Spacer()
-                        Image(systemName: "pencil")
-                            .padding(.trailing, 30)
-                    }
-                }
-                .padding(.top, 30.0)
+                Text("2022.04.03")
+                    .font(.system(size: 15, weight: .regular))
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 30.0)
                 Spacer()
             }
             VStack{

--- a/donggle/donggle/Views/DetailCard/DetailCardFront.swift
+++ b/donggle/donggle/Views/DetailCard/DetailCardFront.swift
@@ -17,17 +17,10 @@ struct DetailCardFront: View {
 
         ZStack(){
             VStack{
-                ZStack(){
-                    Text("2022.04.03")
-                        .font(.system(size: 15, weight: .regular))
-                        .multilineTextAlignment(.center)
-                    HStack(){
-                        Spacer()
-                        Image(systemName: "pencil")
-                            .padding(.trailing, 30)
-                    }
-                }
-                .padding(.top, 30.0)
+                Text("2022.04.03")
+                    .font(.system(size: 15, weight: .regular))
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 30.0)
                 Spacer()
             }
             VStack{


### PR DESCRIPTION
## 작업내용


- CardDetailView
- 네비게이션 바 - 백버튼, more 버튼 추가했고, 액션시트 편집/삭제/취소 버튼까지 만들었습니다
소소하네요..
-DetailCardFront, Back의 카드 R값 조정 (24 ->20)

## 다음으로 진행될 작업

- [ ] 네비게이션 바 타이틀 및 아이콘 크기 조절
- [ ] 액션시트에서 편집 뷰로 연결

## 질문
 - 네비게이션 바 leading과 trailing 버튼에서 제가 설정한 padding 외에도 safe area가 있는것 같은데, 그 값이 16인가요..? safe area 무시하고 마진값 설정할 수 있는 방법이 있나요 ㅜ ㅠ


