### PR TITLE
#59 #60 [Fix] HomeView와 CalendarView 사용자 인터렉션 일부 수정

### DIFF
--- a/donggle/donggle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/donggle/donggle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "9115a992c91fa19cbb4f2241084240d38654a1fc",
         "version" : "1.5.5"
       }
+    },
+    {
+      "identity" : "fscalendar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WenchaoD/FSCalendar.git",
+      "state" : {
+        "revision" : "0fbdec5172fccb90f707472eeaea4ffe095278f6",
+        "version" : "2.8.4"
+      }
     }
   ],
   "version" : 2

--- a/donggle/donggle/Tab bar Views/CalenderView.swift
+++ b/donggle/donggle/Tab bar Views/CalenderView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UIKit
 import FSCalendar
 
-var Mainreward : [Reward] = UserDefaults.rewardArray ?? []
+var mainReward : [Reward] = UserDefaults.rewardArray ?? []
 
 struct CalendarView: View {
     
@@ -61,12 +61,12 @@ struct CalendarView: View {
                     .font(.title2)
                 Button("보상전체 출력"){
                         print("--- 보상상 ---")
-                        print(Mainreward)
+                        print(mainReward)
                         print("-----------------")
                 }
                 
                 ScrollView {
-                    let currentInfo = Mainreward.filter { (reward : Reward ) -> Bool in
+                    let currentInfo = mainReward.filter { (reward : Reward ) -> Bool in
                         
                         let formatter = DateFormatter()
                         formatter.dateFormat = "YYYY년 M월 d일"
@@ -105,7 +105,7 @@ struct CalendarView: View {
                                         )
                                     }.padding(10)
                                         .fullScreenCover(isPresented: $isDetailView) {
-                                            DetailView(isFullScreen: $isDetailView)
+                                            DetailView(isFullScreen: $isDetailView, reward : reward)
                                         }
                                     if(reward.isEffective == nil){
                                         rewardCard.foregroundColor(Color.blue)
@@ -192,7 +192,7 @@ struct CalendarRepresentable: UIViewRepresentable{
     class Coordinator: NSObject, FSCalendarDelegate, FSCalendarDataSource{
         var parent: CalendarRepresentable
         
-        let rewardEvents : [String] = Mainreward.map({(reward) in
+        let rewardEvents : [String] = mainReward.map({(reward) in
             let formatter = DateFormatter()
             formatter.dateFormat = "YYYY년 M월 d일"
             return formatter.string(from: reward.date)

--- a/donggle/donggle/Tab bar Views/CalenderView.swift
+++ b/donggle/donggle/Tab bar Views/CalenderView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 import UIKit
 import FSCalendar
 
-var mainReward : [Reward] = UserDefaults.rewardArray ?? []
-
 struct CalendarView: View {
     
     static let dateFormatText: DateFormatter = {
@@ -37,22 +35,22 @@ struct CalendarView: View {
                 VStack{
                     CalendarRepresentable(selectedDate: $selectedDate)
                 }
-                    .datePickerStyle(.graphical)
-                    .navigationBarTitle(Text("보상캘린더"))
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarItem(placement: ToolbarItemPlacement.navigationBarTrailing) {
-                            Button(action: {
-                                isRecordView.toggle()
-                            }) {
-                                Image(systemName: "plus")
-                            }
-                            .fullScreenCover(isPresented: $isRecordView) {
-                                RecordRewardView(isFullScreen: $isRecordView)
-                            }
-                        } // : ToolbarItem
-                    } // : toolbar
-                    .padding(10)
+                .datePickerStyle(.graphical)
+                .navigationBarTitle(Text("보상캘린더"))
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: ToolbarItemPlacement.navigationBarTrailing) {
+                        Button(action: {
+                            isRecordView.toggle()
+                        }) {
+                            Image(systemName: "plus")
+                        }
+                        .fullScreenCover(isPresented: $isRecordView) {
+                            RecordRewardView(isFullScreen: $isRecordView)
+                        }
+                    } // : ToolbarItem
+                } // : toolbar
+                .padding(10)
                 
                 Divider()
                 
@@ -60,9 +58,9 @@ struct CalendarView: View {
                     .padding(10)
                     .font(.title2)
                 Button("보상전체 출력"){
-                        print("--- 보상상 ---")
-                        print(mainReward)
-                        print("-----------------")
+                    print("--- 보상상 ---")
+                    print(mainReward)
+                    print("-----------------")
                 }
                 
                 ScrollView {
@@ -93,8 +91,8 @@ struct CalendarView: View {
                                     }){
                                         //gridView // lazyHgrid 찾아보기 !
                                         VStack{
-                                                Text("\(reward.category[0])")
-//                                                    .font(Font.system(size: 50, design: .default))
+                                            Text("\(reward.category[0])")
+                                            //                                                    .font(Font.system(size: 50, design: .default))
                                             Text("\(reward.title)").foregroundColor(Color.black)
                                         }// : VStack
                                         .padding(20)
@@ -140,7 +138,7 @@ struct CalendarRepresentable: UIViewRepresentable{
         
         // 색 시정
         // 캘린더 배경 색
-//        calendar.backgroundColor = UIColor(red: 241/255, green: 249/255, blue: 255/255, alpha: 1)
+        //        calendar.backgroundColor = UIColor(red: 241/255, green: 249/255, blue: 255/255, alpha: 1)
         
         // 선택한 날짜 색
         calendar.appearance.selectionColor = UIColor(red: 38/255, green: 153/255, blue: 251/255, alpha: 1)
@@ -178,13 +176,12 @@ struct CalendarRepresentable: UIViewRepresentable{
         calendar.appearance.headerTitleFont = UIFont.systemFont(ofSize: 24)
         
         
-//        calendar.locale = Locale(identifier: "ko_KR") // 일 월 화 수 목 금
+        //        calendar.locale = Locale(identifier: "ko_KR") // 일 월 화 수 목 금
         calendar.appearance.weekdayTextColor = .gray
         
         return calendar
     }
-    
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
@@ -192,41 +189,14 @@ struct CalendarRepresentable: UIViewRepresentable{
     class Coordinator: NSObject, FSCalendarDelegate, FSCalendarDataSource{
         var parent: CalendarRepresentable
         
-        let rewardEvents : [String] = mainReward.map({(reward) in
-            let formatter = DateFormatter()
-            formatter.dateFormat = "YYYY년 M월 d일"
-            return formatter.string(from: reward.date)
-        })
-        
         init(_ parent: CalendarRepresentable) {
             self.parent = parent
         }
         
         // 날짜 선택 시 콜백 메소드
-                func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
-                    parent.selectedDate = date
-                }
-        
-        
-        // 하단에 글자 남기기
-        //        func calendar(_ calendar: FSCalendar, subtitleFor date: Date) -> String? {
-        //
-        //                let dateFormatter = DateFormatter()
-        //                dateFormatter.dateFormat = "yyyy-MM-dd"
-        //
-        //                switch dateFormatter.string(from: date) {
-        //                case dateFormatter.string(from: Date()):
-        //                    return "오늘"
-        //                case "2022-04-22":
-        //                    return "출근"
-        //                case "2022-04-23":
-        //                    return "지각"
-        //                case "2022-04-24":
-        //                    return "결근"
-        //                default:
-        //                    return nil
-        //                }
-        //            }
+        func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+            parent.selectedDate = date
+        }
         
         // dot size
         func calendar(_ calendar: FSCalendar, willDisplay cell: FSCalendarCell, for date: Date, at monthPosition: FSCalendarMonthPosition) {
@@ -234,9 +204,14 @@ struct CalendarRepresentable: UIViewRepresentable{
             cell.eventIndicator.transform = CGAffineTransform(scaleX: eventScaleFactor, y: eventScaleFactor)
         }
         
-        
         // 이벤트 표시 개수
         func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
+            
+            let rewardEvents : [String] = mainReward.map({(reward) in
+                let formatter = DateFormatter()
+                formatter.dateFormat = "YYYY년 M월 d일"
+                return formatter.string(from: reward.date)
+            })
             
             let formatter = DateFormatter()
             formatter.dateFormat = "YYYY년 M월 d일"
@@ -246,49 +221,9 @@ struct CalendarRepresentable: UIViewRepresentable{
             }else{
                 return 0
             }
-            
         }
-        
-        
     }
 }
-
-
-//struct RewardCard_river: View {
-//    @Binding var isDetailView: Bool
-//    @Binding var reward : Reward
-//
-//
-//    struct Reward {
-//        var id: Int
-//        var title: String
-//        var description: String
-//        var date: String
-//        var category: String
-//        var isEffective: Bool?
-//        var stressKey: Int?
-//    }
-//
-//    var body: some View {
-//        Button(action: {
-//            isDetailView.toggle()
-//        }) {
-//            VStack{
-//                Text(reward.category)
-//                    .font(Font.system(size: 50, design: .default))
-//                Text(reward.title)
-//            }.padding(20)
-//                .frame(height: 160)
-//                .overlay(
-//                    RoundedRectangle(cornerRadius: 15)
-//                        .stroke(lineWidth: 1)
-//                )
-//        }.padding(10)
-//            .fullScreenCover(isPresented: $isDetailView) {
-//                DetailView(isFullScreen: $isDetailView)
-//            }.foregroundColor(Color.black)
-//    }
-//}
 
 
 struct CalenderView_Previews: PreviewProvider {

--- a/donggle/donggle/Tab bar Views/HomeView.swift
+++ b/donggle/donggle/Tab bar Views/HomeView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
+
 var dateCircle : [String] = []
 
 //Date String 추출 -> 중복값 삭제 후 정렬
-let RewardDate : [String] = Array(Set(mainReward.map { reward in
+var RewardDate : [String] = Array(Set(mainReward.map { reward in
     let formatter = DateFormatter()
     formatter.dateFormat = "YYYY년 M월 d일"
     
@@ -14,21 +15,27 @@ let RewardDate : [String] = Array(Set(mainReward.map { reward in
 var RewardDateArray : [[Reward]] = []
 
 func InitRewardDateArray() {
+    if(RewardDate.count > 7){
+        RewardDate.removeSubrange(7...RewardDate.count-1)
+    }
     RewardDate.forEach { dateCriteria in
         let DateReward = mainReward.filter{(reward : Reward)-> Bool in
             let formatter = DateFormatter()
             formatter.dateFormat = "YYYY년 M월 d일"
             return dateCriteria == formatter.string(from: reward.date)
         }
-//        print("-------------------")
-//        print(dateCriteria)
-//        //        print(DateReward)
-//        print("-------------------")
+        print("-------------------")
+        print(dateCriteria)
+        //        print(DateReward)
+        print("-------------------")
         RewardDateArray.append(DateReward)
     }
 }
 
 func initDateCircle(){
+    
+    dateCircle = []
+    
     let array = RewardDateArray.map { array -> String in
         let formatter = DateFormatter()
         formatter.dateFormat = "YYYY년 M월 d일"
@@ -39,6 +46,7 @@ func initDateCircle(){
         //        print("--")
         return String(date.split(separator: " ")[2].split(separator: "일")[0])
     }
+    
     dateCircle = array
 }
 
@@ -53,7 +61,7 @@ struct HomeView: View {
     @State var sliderValue : Double = UserDefaults.standard.double(forKey:"sliderValue")
     @State var stressIndex : Int = UserDefaults.standard.integer(forKey:"stressIndex")
     
-    @State private var selectedDate : Int = 0
+    @State private var selectedDate : Int = 1
     
     @GestureState var isLongPressed = false
     @State private var isDetailView = false
@@ -65,9 +73,6 @@ struct HomeView: View {
         let longPressGesture = LongPressGesture()
             .updating($isLongPressed){ newValue, state, transaction in
                 state = newValue
-                
-                InitRewardDateArray()
-                initDateCircle()
             }
         
         let dragGesture = DragGesture()
@@ -81,7 +86,6 @@ struct HomeView: View {
                 Text("동글이")
                     .font(.system(size: 28, weight: .bold))
                     .padding(.leading, 20)
-                    .onAppear()
                 
                 Spacer()
                 Button(action: {
@@ -92,6 +96,10 @@ struct HomeView: View {
                 }
                 .sheet(isPresented: self.$showModal) {
                     RecordView(stressIndex: $stressIndex ,sliderValue: $sliderValue)
+                    .onDisappear{
+                        mainReward = UserDefaults.rewardArray ?? []
+                        print("RecordView is closed")
+                    }
                 }
             }
             .padding()
@@ -114,19 +122,6 @@ struct HomeView: View {
             Spacer().frame(height: 10)
             
             if(dateCircle.count == 0){
-                
-                //                HStack{
-                //                    ForEach(dateCircle1, id: \.self){ index in
-                //                        Button(
-                //                            action: {
-                //                                selectedDate = Int(index) ?? 0
-                //                            }, label:{
-                //                                Text("\(index)")
-                //                            }).buttonStyle(DateButtonStyle())
-                //                    }
-                //                }
-                //                .padding()
-                
                 Text("아직 입력하신 보상이 없습니다 ~ !!")
                     .padding(20)
                     .frame(maxWidth:.infinity)
@@ -136,25 +131,29 @@ struct HomeView: View {
                     ).padding(EdgeInsets(top: 20, leading: 20, bottom: 0, trailing: 20))
                 Spacer()
             }else{
-                ScrollView(.horizontal, showsIndicators: false){
+                // dateCircle
                     HStack{
                         ForEach(dateCircle.indices, id: \.self){ index in
-                            if(index < 7){ // 터치하는 거 알아보기
-                                Button(
-                                    action: {
-                                        selectedDate = index
-                                        initRewardCardInfo(index: index)
-                                    }, label:{
-                                        Text("\(dateCircle[index])")
-                                    }).buttonStyle(DateButtonStyle())
-                            }
+                            Button(
+                                action: {
+                                    selectedDate = index
+                                    initRewardCardInfo(index: index)
+                                }, label:{
+                                    Text("\(dateCircle[index])")
+                                        .foregroundColor(Color.black)
+                                })
+                            .frame(width: 22, height: 22)
+                            .padding(10)
+                            .background(selectedDate == index  ? Color.yellow : Color.white)
+                            .cornerRadius(30)
                         }
                     } // : 날짜 Hstack
                     .padding()
-                } // :ScrollView
-                Spacer()
-                ScrollView(.horizontal, showsIndicators: false){
                     
+                Spacer()
+                
+                //건빵 List
+                ScrollView(.horizontal, showsIndicators: false){
                     HStack{
                         ForEach(RewardCardInfo, id: \.self.id) { reward in
                             VStack{
@@ -173,17 +172,22 @@ struct HomeView: View {
                     }
                 }
             }
-        }    }
+        }
+    }
 }
 
-struct DateButtonStyle: ButtonStyle {
-    func makeBody(configuration: Self.Configuration) -> some View {
-        configuration.label
-            .frame(width: 22, height: 22)
-            .padding(10)
-            .foregroundColor(.white)
-            .background(configuration.isPressed ? Color.yellow : Color.white)
-            .cornerRadius(30)
+struct RewardCard3: View {
+    
+    var body: some View {
+        VStack(){
+            Text("list.Dday")
+                .font(.system(size: 10, weight: .light))
+            Circle().frame(width: 60, height: 60)
+            Text("list.title")
+        }
+        .frame(width: 106.0, height: 140.0)
+        .background(Color.gray)
+        .cornerRadius(20)
     }
 }
 

--- a/donggle/donggle/Tab bar Views/HomeView.swift
+++ b/donggle/donggle/Tab bar Views/HomeView.swift
@@ -47,21 +47,18 @@ func initDateCircle(){
         return String(date.split(separator: " ")[2].split(separator: "일")[0])
     }
     
+    RewardCardInfo = RewardDateArray[0]
     dateCircle = array
 }
 
 var RewardCardInfo : [Reward] = []
-
-func initRewardCardInfo(index : Int){
-    RewardCardInfo = RewardDateArray[index]
-}
 
 struct HomeView: View {
     @State private var showModal = false
     @State var sliderValue : Double = UserDefaults.standard.double(forKey:"sliderValue")
     @State var stressIndex : Int = UserDefaults.standard.integer(forKey:"stressIndex")
     
-    @State private var selectedDate : Int = 1
+    @State private var selectedDate : Int = 0
     
     @GestureState var isLongPressed = false
     @State private var isDetailView = false
@@ -137,7 +134,7 @@ struct HomeView: View {
                             Button(
                                 action: {
                                     selectedDate = index
-                                    initRewardCardInfo(index: index)
+                                    RewardCardInfo = RewardDateArray[index]
                                 }, label:{
                                     Text("\(dateCircle[index])")
                                         .foregroundColor(Color.black)

--- a/donggle/donggle/Tab bar Views/HomeView.swift
+++ b/donggle/donggle/Tab bar Views/HomeView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 
-var mainReward : [Reward] = UserDefaults.rewardArray ?? []
-
 var dateCircle : [String] = []
 
 //Date String 추출 -> 중복값 삭제 후 정렬
@@ -153,7 +151,7 @@ struct HomeView: View {
                         }
                     } // : 날짜 Hstack
                     .padding()
-                }// :ScrollView
+                } // :ScrollView
                 Spacer()
                 ScrollView(.horizontal, showsIndicators: false){
                     
@@ -176,21 +174,6 @@ struct HomeView: View {
                 }
             }
         }    }
-}
-
-
-struct 보상card: View {
-    var title: String
-    var isSelected: Bool
-    var action: () -> Void
-    var body: some View {
-        Button(action: self.action) {
-            VStack{
-                Text("☺️")
-                Text(self.title).foregroundColor(Color.black)
-            }.background(self.isSelected == false ? nil : RoundedRectangle(cornerRadius: 10).fill(Color.init(red: 193/255, green: 233/255, blue: 252/255)))
-        }
-    }
 }
 
 struct DateButtonStyle: ButtonStyle {

--- a/donggle/donggle/Views/DetailView.swift
+++ b/donggle/donggle/Views/DetailView.swift
@@ -11,9 +11,14 @@ import SwiftUI
 struct DetailView: View {
     @Binding var isFullScreen: Bool
     
+    var reward: Reward
+    
     var body: some View {
+        
         NavigationView {
             NavigationLink(destination: CalendarView()) {
+                
+                    DetailContextView(reward: reward)
             }.navigationBarTitle("상세뷰")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -23,8 +28,27 @@ struct DetailView: View {
                         }) {
                             Image(systemName: "chevron.backward")
                         }
-                    }
-                }
+                    } // : ToolbarItem
+                } // : toolbar
+            
+        }// : NavigationView
+        
+        //DetailContextView(reward: reward)
+        
+    }
+}
+
+
+
+struct DetailContextView: View {
+    
+    var reward: Reward
+    var body: some View {
+        VStack{
+            Text("\(reward.category[0])")
+            Text("\(reward.title)")
+            Text("\(reward.content)")
+            Text("\(reward.date)")
         }
     }
 }

--- a/donggle/donggle/Views/ProgressBar.swift
+++ b/donggle/donggle/Views/ProgressBar.swift
@@ -19,7 +19,6 @@ struct ProgressBar: View {
             Text("인간관계가 가장 스트레스에요")
                 .font(.system(size: 22, weight: .bold))
                 .frame(maxWidth: width, alignment: .leading)
-                
             
             ZStack(alignment: .leading) {
                 Rectangle()

--- a/donggle/donggle/Views/RecordView.swift
+++ b/donggle/donggle/Views/RecordView.swift
@@ -18,8 +18,10 @@ struct MultipleSelectionRow: View {
 
 struct RecordView: View {
     @Environment(\.dismiss) private var dismiss
+    
     @Binding var stressIndex: Int
     @Binding var sliderValue : Double
+    
     @State var stressSelectionOn: Bool = false
     @State var rewardSelectionOn: Bool = false
     @State var rewardIsOn: Bool = false

--- a/donggle/donggle/Views/StressReportView.swift
+++ b/donggle/donggle/Views/StressReportView.swift
@@ -56,10 +56,12 @@ struct StressReportView: View {
                 .padding(32)
             
             VStack {
-                ForEach(stressSet, id: \.self.id) { stress in
-                    ListRow(title: stress.category[0], category: stress.category[0])
-                        .padding(.vertical, 8)
-                }
+//                ForEach(stressSet, id: \.self.id) { stress in
+//                    ListRow(
+//                        title: stress.content,
+//                        category: stress.category[0])
+//                        .padding(.vertical, 8)
+//                }
             }
             .padding(.horizontal, 32)
         }

--- a/donggle/donggle/Views/TabBarView.swift
+++ b/donggle/donggle/Views/TabBarView.swift
@@ -15,7 +15,10 @@ struct TabBarView: View{
         UITabBar.appearance().backgroundColor = UIColor.white
     }
     
+    
     var body: some View{
+        
+        var mainReward : [Reward] = UserDefaults.rewardArray ?? []
         
         TabView(selection:$selection){
             HomeView()
@@ -35,6 +38,9 @@ struct TabBarView: View{
                     Image(systemName: "square.and.pencil")
                     Text("Calendar")
                 }.tag(3)
+                .onAppear{
+                    print("hi")
+                }
             
             SettingView()
                 .tabItem {

--- a/donggle/donggle/Views/TabBarView.swift
+++ b/donggle/donggle/Views/TabBarView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+var mainReward : [Reward] = UserDefaults.rewardArray ?? []
+
 
 struct TabBarView: View{
     @State private var selection = 1
@@ -15,10 +17,7 @@ struct TabBarView: View{
         UITabBar.appearance().backgroundColor = UIColor.white
     }
     
-    
     var body: some View{
-        
-        var mainReward : [Reward] = UserDefaults.rewardArray ?? []
         
         TabView(selection:$selection){
             HomeView()
@@ -26,6 +25,10 @@ struct TabBarView: View{
                     Image(systemName: "house")
                     Text("Home")
                 }.tag(1)
+                .onAppear{
+                    InitRewardDateArray()
+                    initDateCircle()
+                }
 
             ReportView()
                 .tabItem {
@@ -38,9 +41,6 @@ struct TabBarView: View{
                     Image(systemName: "square.and.pencil")
                     Text("Calendar")
                 }.tag(3)
-                .onAppear{
-                    print("hi")
-                }
             
             SettingView()
                 .tabItem {


### PR DESCRIPTION
## 작업내용
### 보상 캘린더 구현
- [x] 상세뷰에 해당 건빵 info 매개변수로 넘기기

### HomeView 밑에 건빵 리스트 
- [x] 원형 일자 선택 시 건빵 내용 보이게 하기
- [x] 일자 원형 개수 제한
- [x] 건빵 스크롤 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/82457928/162680676-b8228be7-0334-4657-a2d5-afb7deaf7ba7.gif)

---------------------------------------

##  리뷰포인트
- @yungahui 
1) 보상 캘린더에서 건빵 클릭 -> 해당 보상 건빵의 내용을 다음 DetailView로 가지고 감  
: 이때 이솝님이 만드신 DetailCard랑 연결이 되야 합니다! 안에 들어갈 내용들을 넘겨드렸어요! 연결 작업 부탁드립니다.
2) HomeView에서 일자가 7일보다 작으면 가운데 정렬로 해놨는데 좌측으로 정렬할까요??

- @Gobans 
1) 보상 캘린더에서 우측 상단의 기록하기 버튼 클릭시
: 보상 기록하기 View로 넘어가야 합니다! 연결 작업 부탁드립니다.

## 질문
### HomeView에서 가끔 원형일자가 7개보다 많아지는데 그렇게 만드는 트리거 행동이 뭔지 모르겠습니다. 찾으신 분이 있다면 알려주세요 !
---------------------------------------

## 다음으로 진행될 작업
### 보상 캘린더 구현 
- [ ] 이솝이 드로윙 해준 걸로 디자인 갈기
- [ ] dot 바인딩 

### HomeView 밑에 건빵 리스트 
- [ ] View가 열릴 때 바로 건빵과 일자원형 보이게 하기
- [ ] 이솝이 드로윙 해준 걸로 디자인 갈기

( 우선 순위 뒤의 것)
### 보상 캘린더 구현 
- [ ] 보상 캘린더에서  일자 하단에 dot 보상 완료 유무로 dot 색 변경

## 개인 메모
### UserDefault 값 View에서 바로바로 바인딩되어서 쓰기
- [ ] UserDefault값 자체는 바인딩이 되는데, 그 값을 가공해서 쓰면 바인딩이 안되는 것 같음. UserDefault값이 바뀌면 함수를 실행하는 방법을 알아봐야겠음.

