### PR TITLE
#53[Refactor] 기록 뷰 디자인 수정& SRdata 수정

### DIFF
--- a/donggle/donggle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/donggle/donggle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -8,6 +8,15 @@
         "revision" : "9115a992c91fa19cbb4f2241084240d38654a1fc",
         "version" : "1.5.5"
       }
+    },
+    {
+      "identity" : "fscalendar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WenchaoD/FSCalendar.git",
+      "state" : {
+        "revision" : "0fbdec5172fccb90f707472eeaea4ffe095278f6",
+        "version" : "2.8.4"
+      }
     }
   ],
   "version" : 2

--- a/donggle/donggle/Model/SRdata.swift
+++ b/donggle/donggle/Model/SRdata.swift
@@ -52,6 +52,8 @@ func stringToImoticon(category:String) -> String {
     case "알콜":
         return "🍻"
 // -----보상--------
+    case "기타":
+        return "🧚‍♀️"
 
     default:
         return "🈚️"

--- a/donggle/donggle/Model/SRdata.swift
+++ b/donggle/donggle/Model/SRdata.swift
@@ -26,6 +26,40 @@ struct Reward : Codable{
     var stressKey : UUID?
 }
 
+func stringToImoticon(category:String) -> String {
+    switch category{
+    case "직장":
+        return "🧳"
+    case "날씨":
+        return "🌤"
+    case "수면":
+        return "🤤"
+    case "가족":
+        return "👨‍👩‍👧‍👦"
+    case "금전":
+        return "💵"
+// -----스트레스--------
+    case "쇼핑":
+        return "🛒"
+    case "운동":
+        return "🏋️‍♀️"
+    case "음식":
+        return "🍚"
+    case "놀기":
+        return "🕺"
+    case "잠자기":
+        return "💤"
+    case "알콜":
+        return "🍻"
+// -----보상--------
+
+    default:
+        return "🈚️"
+    }
+}
+
+
+
 extension UserDefaults {
     
     static var stressArray: [Stress]? {

--- a/donggle/donggle/Views/RecordView.swift
+++ b/donggle/donggle/Views/RecordView.swift
@@ -9,7 +9,7 @@ struct MultipleSelectionRow: View {
     var body: some View {
         Button(action: self.action) {
             VStack{
-                Text("☺️")
+                Text(stringToImoticon(category:self.title))
                 Text(self.title).foregroundColor(Color.black)
             }.background(self.isSelected == false ? nil : RoundedRectangle(cornerRadius: 10).fill(Color.init(red: 193/255, green: 233/255, blue: 252/255)))
         }
@@ -17,47 +17,57 @@ struct MultipleSelectionRow: View {
 }
 
 struct RecordView: View {
+
     @Environment(\.dismiss) private var dismiss
     @Binding var stressIndex: Int
     @Binding var sliderValue : Double
     @State var stressSelectionOn: Bool = false
     @State var rewardSelectionOn: Bool = false
     @State var rewardIsOn: Bool = false
-    @State var stressDescription: String = "스트레스 내용"
-    @State var rewardDescription: String = "보상 내용"
+    @State var rewardGroupOn: Bool = false
+    @State var stressDescription: String = "어떤 일이 있었나요?"
+    @State var rewardDescription: String = "나에게 어떤 선물을 줄까요?"
     @State var rewardTitle: String = ""
     @State var selectedStress: [String] = []
     @State var selectedReward: [String] = []
-    @State var stressCategory: [String] = ["직장", "날씨", "수면", "가족", "돈", "그냥"]
+    @State var stressCategory: [String] = ["직장", "날씨", "수면", "가족", "금전"]
     @State var rewardCategory: [String] = ["잠자기", "알콜", "쇼핑", "운동", "음식", "놀기"]
     @State private var rewardDate = Date()
     
     var columns: [GridItem] = Array(repeating: .init(.flexible()), count: 4)
-    
     func saveRecord(sliderValue: Double, stressDescription: String, selectedStress : [String], rewardIsOn : Bool, rewardTitle: String, rewardDescription : String, selectedReward : [String], rewardDate : Date){
-        if stressDescription.isEmpty || stressDescription == "스트레스 내용" && selectedStress.isEmpty && !rewardIsOn{
-    //    스트레스 수치만 조절
+        if stressDescription.isEmpty || stressDescription == "어떤 일이 있었나요?" && selectedStress.isEmpty && !rewardIsOn{
+            //    스트레스 수치만 조절
             print("---스트레스 수치만 조절---")
         }else if !rewardIsOn{
-        //    스트레스 기록만
+            //    스트레스 기록만
+            if selectedStress.isEmpty{
+                self.selectedStress.append("기타")
+            }
             var sArray : [Stress] = UserDefaults.stressArray ?? []
-            let stressInstance = Stress(id: UUID(), index: stressIndex, content: stressDescription, date: Date(), category: selectedStress, rewardKey: nil)
+            let stressInstance = Stress(id: UUID(), index: stressIndex, content: stressDescription, date: Date(), category: self.selectedStress, rewardKey: nil)
             sArray.append(stressInstance)
             UserDefaults.stressArray = sArray
             print("---스트레스만 기록---")
             print(sArray)
             print("-----------------")
         }else{
-        //    스트레스 + 보상 기록
+            //    스트레스 + 보상 기록
+            if selectedStress.isEmpty{
+                self.selectedStress.append("기타")
+            }
+            if selectedReward.isEmpty{
+                self.selectedReward.append("기타")
+            }
             let stressUUID = UUID()
             let rewardUUID = UUID()
             var sArray : [Stress] = UserDefaults.stressArray ?? []
-            let stressInstance = Stress(id: stressUUID, index: self.stressIndex, content: stressDescription, date: Date(), category: selectedStress, rewardKey: rewardUUID)
+            let stressInstance = Stress(id: stressUUID, index: self.stressIndex, content: stressDescription, date: Date(), category: self.selectedStress, rewardKey: rewardUUID)
             sArray.append(stressInstance)
             UserDefaults.stressArray = sArray
             
             var rArray : [Reward] = UserDefaults.rewardArray ?? []
-            let rewardInstance = Reward(id: rewardUUID, title: rewardTitle, content: rewardDescription, date: rewardDate, category: selectedReward, isEffective: nil, stressKey: stressUUID)
+            let rewardInstance = Reward(id: rewardUUID, title: rewardTitle, content: rewardDescription, date: rewardDate, category: self.selectedReward, isEffective: nil, stressKey: stressUUID)
             rArray.append(rewardInstance)
             UserDefaults.rewardArray = rArray
             
@@ -67,85 +77,107 @@ struct RecordView: View {
             print("-----------------")
         }
     }
-    
+
     var body: some View {
         NavigationView{
             Form {
                 Section{
+                    Text("스트레스 지수")
+                        .multilineTextAlignment(.leading)
                     VStack{
+                        Text("\(Int(sliderValue))%")
                         Circle()
                             .fill(Color.init(red: (sliderValue+1)*2/255, green: (101-sliderValue)*2/255, blue: (101-sliderValue)*2/255))
                             .padding()
                             .frame(width: 130.0, height: 120.0)
-                        Text("\(Int(sliderValue))%")
                         HStack{
                             Text("😄")
                             Slider(value: $sliderValue, in: 0...100,step: 1.0)
                             Text("🤯")
                         }
- 
+                        
                     }
                 }
-                TextEditor(text: $stressDescription)
-                    .foregroundColor(self.stressDescription == "스트레스 내용" ? .gray : .primary)
-                    .onTapGesture {
-                        if self.stressDescription == "스트레스 내용"{
-                            self.stressDescription = ""
-                        }
-                    }
-                    .frame(height: 100.0)
-                DisclosureGroup("스트레스 요인", isExpanded: $stressSelectionOn){
-                    ScrollView {
-                        LazyVGrid(columns: columns,spacing: 20){
-                            ForEach(self.stressCategory, id: \.self) { item in
-                                MultipleSelectionRow(title: item, isSelected: self.selectedStress.contains(item)) {
-                                    if self.selectedStress.contains(item) {
-                                        self.selectedStress.removeAll(where: { $0 == item })
-                                    }
-                                    else {
-                                        self.selectedStress.append(item)
-                                    }
-                                }
+                VStack(alignment: .leading, spacing: 30){
+                    Text("스트레스 요인")
+                        .multilineTextAlignment(.leading)
+                    TextEditor(text: $stressDescription)
+                        .foregroundColor(self.stressDescription == "어떤 일이 있었나요?" ? .gray : .primary)
+                        .onTapGesture {
+                            if self.stressDescription == "어떤 일이 있었나요?"{
+                                self.stressDescription = ""
                             }
-                        }
-                        .padding(.horizontal)
-                    }
+                        }.background(RoundedRectangle(cornerRadius: 20).fill(Color(red: 247/255, green: 247/255, blue: 247/255)))
+                        .frame(height:100)
+   
                 }
                 Section{
-                    Toggle(isOn: $rewardIsOn) {
-                        Text("보상 추가")
-                    }
-                    if rewardIsOn{
-                        TextField("보상 제목", text: $rewardTitle)
-                        TextEditor(text: $rewardDescription)
-                            .foregroundColor(self.rewardDescription == "보상 내용" ? .gray : .primary)
-                            .onTapGesture {
-                                if self.rewardDescription == "보상 내용"{
-                                    self.rewardDescription = ""
-                                }
-                            }
-                            .frame(height: 100.0)
-                        DatePicker(selection: $rewardDate, in: Date()..., displayedComponents: .date , label: { Text("날짜") })
-                        DisclosureGroup("활동", isExpanded: $rewardSelectionOn){
-                            ScrollView{
-                                LazyVGrid(columns: columns,spacing: 20){
-                                    ForEach(self.rewardCategory, id: \.self) { item in
-                                        MultipleSelectionRow(title: item, isSelected: self.selectedReward.contains(item)) {
-                                            if self.selectedReward.contains(item) {
-                                                self.selectedReward.removeAll(where: { $0 == item })
-                                            }
-                                            else {
-                                                self.selectedReward.append(item)
-                                            }
+                    DisclosureGroup("스트레스 카테고리", isExpanded: $stressSelectionOn){
+                        ScrollView {
+                            LazyVGrid(columns: columns,spacing: 20){
+                                ForEach(self.stressCategory, id: \.self) { item in
+                                    MultipleSelectionRow(title: item,isSelected: self.selectedStress.contains(item)) {
+                                        if self.selectedStress.contains(item) {
+                                            self.selectedStress.removeAll(where: { $0 == item })
+                                        }
+                                        else {
+                                            self.selectedStress.append(item)
                                         }
                                     }
                                 }
                             }
+                            .padding(.horizontal)
                         }
                     }
                 }
+                Toggle(isOn: $rewardIsOn) {
+                    Text("보상 추가")
+                }
+                if rewardIsOn{
+                    Section{
+                    DisclosureGroup("보상", isExpanded: $rewardGroupOn){
+                        VStack(alignment: .leading, spacing: 30){
+                            DatePicker(selection: $rewardDate, in: Date()..., displayedComponents: .date , label: { Text("날짜") })
+                                .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
+                            Text("보상 이름")
+                            TextField("", text: $rewardTitle)
+                                .background(RoundedRectangle(cornerRadius: 20).fill(Color(red: 247/255, green: 247/255, blue: 247/255)))
+                            Text("보상 내용")
+                            
+                            TextEditor(text: $rewardDescription)
+                                .foregroundColor(self.rewardDescription == "나에게 어떤 선물을 줄까요?" ? .gray : .primary)
+                                .onTapGesture {
+                                    if self.rewardDescription == "나에게 어떤 선물을 줄까요?"{
+                                        self.rewardDescription = ""
+                                    }
+                                }
+                                .background(RoundedRectangle(cornerRadius: 20).fill(Color(red: 247/255, green: 247/255, blue: 247/255)))
+                                .frame(height:100)
+
+                        }
+                            Section{
+                            DisclosureGroup("보상 카테고리", isExpanded: $rewardSelectionOn ){
+                                ScrollView{
+                                    LazyVGrid(columns: columns,spacing: 20){
+                                        ForEach(self.rewardCategory, id: \.self) { item in
+                                            MultipleSelectionRow(title: item, isSelected: self.selectedReward.contains(item)) {
+                                                if self.selectedReward.contains(item) {
+                                                    self.selectedReward.removeAll(where: { $0 == item })
+                                                }
+                                                else {
+                                                    self.selectedReward.append(item)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }.padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
+                        }
+                    }
+                }
+                }
             }
-            .navigationTitle(Text("기록하기"))
+            .navigationTitle(Text("스트레스 기록"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar{
                 ToolbarItem(placement: .navigationBarLeading){
@@ -165,6 +197,13 @@ struct RecordView: View {
                         dismiss()
                     }
                 }
+            }
+            .background(Color.white)
+            .onAppear {
+              UITableView.appearance().backgroundColor = .clear
+            }
+            .onDisappear {
+              UITableView.appearance().backgroundColor = .systemGroupedBackground
             }
         }
     }


### PR DESCRIPTION
## 작업내용

RecordView가 sketch의 변경된 기록 뷰 디자인에 따라 새롭게 단장하였습니다.

![2022-04-11 21 21 19](https://user-images.githubusercontent.com/56781342/162738262-b86b15fe-c81f-44f9-88a6-4e35387e53f7.gif)

SRdata에 stringToImoticon 함수를 만들었습니다. 이 함수를 사용하면 UserDefaults의 카테고리 문자열 하나를 넣으면 이모티콘을 반환해줍니다. **여러분이 생각하는 스트레스와 보상을 추가하거나 저한테 "단어" : "이모티콘" 짝으로 보내주세요.** 

<img width="497" alt="image" src="https://user-images.githubusercontent.com/56781342/162738521-207bcb96-25c4-4134-b7cc-61a95155681c.png">

직접 추가하는 경우 RecordView에서 직접 단어를 추가해줘야 합니다!


<img width="722" alt="image" src="https://user-images.githubusercontent.com/56781342/162739207-aaf4e730-7c6c-4903-ac30-f7e0ee27bdfe.png">


**사용자가 스트레스, 보상 카테고리 미선택시 "기타"로 저장됩니다.**
<img width="157" alt="image" src="https://user-images.githubusercontent.com/56781342/162739734-c0df3405-da17-485b-89e1-e1959f1ca4da.png">





##  리뷰포인트
- RecordView, SRdata


## 다음으로 진행될 작업

- [ ] [Refactor]보상 이름의 텍스트 필드 백그라운드 크기 키우기 (frame으로는 크기가 안커져요😢)
 
<img width="291" alt="image" src="https://user-images.githubusercontent.com/56781342/162740284-ea623dd7-d5e0-480a-ae43-ee56afae7cb5.png">


## 질문
-  sketch에 없던 보상 추가 토글을 추가하였습니다. DisclosureGroup으로 보상 설정을 구현하면 유저의 의도가 엄청 모호해지고 (보상 설정을 하려고 연건지 그냥 열어본건지) 선택을 꼭 해야할 것만 같은 느낌이라 추가했어요. 괜찮을까요?
- SF symbols에 svg 가져와서 이 아이콘 두개를 다른걸로 대체하려는데 ?로 뜨면서 인식이 안되네요.. 저만 안되나요? 
<img width="322" alt="image" src="https://user-images.githubusercontent.com/56781342/162740796-2f7dd0f6-4d50-4f73-866a-007fc31f93dd.png">

 
## References
