### PR TITLE
#67 [Feat] 타임라인에 UserDefaults 데이터 바로 반영되도록 만들기&탭 클릭시 리포트 화면 띄우기

### DIFF
--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -39,17 +39,14 @@ class Datas {
 struct TimelineView: View {
     @State private var date = Date()
     @State private var showModal = false
-    @State private var selectedView = 1
+    @State private var selectedView = 2
     @Environment(\.presentationMode) var presentation
     
     //스트레스, 보상 데이터 임시 정의
     
     var date1 = Date()
     var sortedData = Datas()
-    
-    
-//    UserDefaults.rewardArray
-//    UserDefaults.stressArray
+    //    @State private var prevDate : Date = Date()
     
     
     
@@ -80,9 +77,6 @@ struct TimelineView: View {
                     Text("보상").tag(3)
                     
                 }
-//                .onChange(of: selectedView, perform: { (value) in
-//                    sortedData.refreshDatas()
-//                })
                 
             }
             .padding([.leading, .trailing])
@@ -92,18 +86,15 @@ struct TimelineView: View {
                 
                 
                 ScrollView(showsIndicators: false) {
-                    LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
-                        
-                        
+                    LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 12){
                         ForEach(sortedData.totalSet, id: \.self.id){ data in
                             //type 2 : 스트레스 데이터
                             if data.type == 2 {
+                                stressTimeCard(stressIndex: sortedData.stressSet[data.index].index, stressContent: sortedData.stressSet[data.index].content, stressCategory: sortedData.stressSet[data.index].category, stressDate: dateToString(dateInfo: sortedData.stressSet[data.index].date))
                                 
-                                stressTimeCard(stressIndex: sortedData.stressSet[data.index].index, stressContent: sortedData.stressSet[data.index].content, stressCateList: getStressCateList(stressCategory : sortedData.stressSet[data.index].category), stressDate: dateToString(dateInfo: sortedData.stressSet[data.index].date))
                                 //type 3 : 보상 데이터
                             } else if data.type == 3 {
-                                //                                        rewardData = sortedData.rewardSet[data.index]
-                                RewardTimeCard(rewardIcon: "🍺", rewardName: sortedData.rewardSet[data.index].category[0], rewardTitle: sortedData.rewardSet[data.index].title, rewardContent: sortedData.rewardSet[data.index].content, rewardDate: dateToString(dateInfo: sortedData.rewardSet[data.index].date))
+                                RewardTimeCard(rewardName: sortedData.rewardSet[data.index].category[0], rewardTitle: sortedData.rewardSet[data.index].title, rewardContent: sortedData.rewardSet[data.index].content, rewardDate: dateToString(dateInfo: sortedData.rewardSet[data.index].date))
                             } else {
                                 Text("no data")
                             }
@@ -111,34 +102,33 @@ struct TimelineView: View {
                         
                     }
                 }
-                .padding(.horizontal, 10.0)
+                .padding(.horizontal, 24.0)
                 
             }else if (selectedView == 2){ //스트레스
                 ScrollView(showsIndicators: false) {
-                    LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
+                    LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 12){
                         ForEach(sortedData.stressSet, id: \.self.id) { stress in
-                            stressTimeCard(stressIndex:stress.index, stressContent: stress.content, stressCateList: getStressCateList(stressCategory : stress.category), stressDate: dateToString(dateInfo: stress.date))
+                            stressTimeCard( stressIndex:stress.index, stressContent: stress.content, stressCategory: stress.category, stressDate: dateToString(dateInfo: stress.date))
                         }
                     }
                 }
-                .padding(.horizontal, 10.0)
+                .padding(.horizontal, 24.0)
                 
             } else if (selectedView == 3){ //보상
                 ScrollView(showsIndicators: false) {
-                    LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 5){
+                    LazyVGrid(columns: [GridItem()], alignment: .center, spacing: 12){
                         ForEach(sortedData.rewardSet, id: \.self.id) { reward in
-                            RewardTimeCard(rewardIcon: "🍺", rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content, rewardDate: dateToString(dateInfo: reward.date))
+                            RewardTimeCard(rewardName: reward.category[0], rewardTitle: reward.title, rewardContent: reward.content, rewardDate: dateToString(dateInfo: reward.date))
                         }
                     }
                 }
-                .padding(.horizontal, 10.0)
+                .padding(.horizontal, 24.0)
             } else {
                 Text("no page")
             }
             
         }
         .navigationBarTitle("타임라인", displayMode: .inline)
-//        .isDetailLink(false)
         .onAppear {
             sortedData.refreshDatas()
         }
@@ -151,43 +141,33 @@ struct TimelineView: View {
 
 
 struct RewardTimeCard : View {
-    var rewardIcon: String
     var rewardName: String
     var rewardTitle: String
     var rewardContent: String
     var rewardDate: String
     var body: some View {
-        VStack(spacing: 5.0){
-            Text(rewardDate)
-                .font(.title3)
-                .fontWeight(.bold)
-                .padding(.leading, 5.0)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            
-            HStack(alignment: .center){
-                VStack(alignment: .center){
-                    Text(rewardIcon)
-                        .font(Font.system(size: 50, design: .default))
-                    Text(rewardName)
-                        .fontWeight(.bold)
-                }.padding(10.0)
-                    .frame(width: 80)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 15)
-                            .stroke(lineWidth: 1)
-                    )
+        HStack(alignment: .top, spacing: 0){
+            VStack{
+                Text(stringToImoticon(category : rewardName))
+                    .font(.system(size: 44))
+                //                    .onTapGesture {
+                //                        print("tap")
+                //                    }
                 
-                Spacer()
-                VStack(alignment: .leading){
-                    Text(rewardTitle)
-                        .fontWeight(.bold)
-                    Divider()
-                    Text(rewardContent)
-                    Spacer()
-                }
             }
+            .padding(.trailing, 20.0)
+            VStack(alignment: .leading, spacing: 0){
+                Text(rewardTitle)
+                    .fontWeight(.bold)
+                    .padding(.bottom, 12.0)
+                Text(rewardContent)
+                Spacer()
+            }
+            
+            Spacer()
         }
-        .padding(.all, 5.0)
+        .padding(.vertical, 20.0)
+        .padding(.horizontal, 24.0)
         .background(RoundedRectangle(cornerRadius: 15)
             .foregroundColor(/*@START_MENU_TOKEN@*//*@PLACEHOLDER=View@*/Color(hue: 1.0, saturation: 0.0, brightness: 0.926)/*@END_MENU_TOKEN@*/)
         )
@@ -199,59 +179,52 @@ struct RewardTimeCard : View {
 struct stressTimeCard : View {
     var stressIndex: Int
     var stressContent: String
-    var stressCateList: String
+    var stressCategory: [String]
     var stressDate: String
     
     var body: some View {
-        VStack(spacing: 5.0){
-            Text(stressDate)
-                .font(.title3)
-                .fontWeight(.bold)
-                .padding(.leading, 5.0)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        
+        HStack(alignment: .top, spacing: 0){
+            VStack{
+                Circle()
+                    .fill(Color.gray)
+                    .frame(width:50, height:50)
+                Text(String(stressIndex))
+                    .font(.system(size: 12))
+            }.padding(.trailing, 20)
             
-            HStack(alignment: .center){
-                VStack(alignment: .center){
-                    Circle()
-                        .fill(Color.gray)
-                    Text(String(stressIndex))
-                    Spacer()
-                }.padding(10.0)
-                    .frame(width: 80, height: 100)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 15)
-                            .stroke(lineWidth: 0)
-                    )
-                
-                VStack(alignment: .leading, spacing: 3.0){
-                    HStack(alignment: .top){ //카테고리 두 줄 이상일 때 위쪽으로 정렬되도록
-                        
-                        Text("스트레스")
-                            .padding(.horizontal, 5.0)
-                            .foregroundColor(.white)
-                            .background(RoundedRectangle(cornerRadius: 15)
-                                .foregroundColor(.gray)
-                            )
-                        
-                        Text(stressCateList)
-                        Spacer()
-                    }
+            VStack(alignment: .leading, spacing: 12.0){
+                Text(stressContent)
+                    .font(.system(size: 17))
+                HStack(alignment: .top){ //카테고리 두 줄 이상일 때 위쪽으로 정렬되도록
+//                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 80))]) {
+                        ForEach(stressCategory, id:\.self){ category in
+                            Text(category)
+                                .font(.system(size:12))
+                                .padding(.horizontal, 5.0)
+                                .foregroundColor(.white)
+                                .background(RoundedRectangle(cornerRadius: 15)
+                                    .foregroundColor(.gray)
+                                )
+                        }
+//                    }
                     
-                    Text(stressContent)
-                        .font(.body)
                     Spacer()
                 }
+                Spacer()
             }
+            Spacer()
         }
-        .padding(.all, 5.0)
+        .padding(.vertical, 20.0)
+        .padding(.horizontal, 24.0)
         .background(RoundedRectangle(cornerRadius: 15)
             .foregroundColor(/*@START_MENU_TOKEN@*//*@PLACEHOLDER=View@*/Color(hue: 1.0, saturation: 0.0, brightness: 0.926)/*@END_MENU_TOKEN@*/)
         )
         
-        
     }
     
 }
+
 
 
 
@@ -273,15 +246,6 @@ func createTotalData(stressSet : [Stress], rewardSet : [Reward]) -> [Total]{
     return totalSet
 }
 
-
-//데이터 로드 function
-//func refreshData() -> Datas{
-//    var sortedData : Datas
-//
-//    sortedData = Datas(stressSet: mainStress ?? [], rewardSet: mainReward ?? [])
-//
-//    return sortedData
-//}
 
 
 //여러개의 카테고리가 ","로 구분되어 나열된 string 만들기

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -10,32 +10,47 @@ struct Total {
 }
 
 
+
+class Datas {
+    var stressSet : [Stress]
+    var rewardSet : [Reward]
+    var totalSet : [Total]
+    
+    //date 기준 내림차순 정렬
+    init(){
+        self.stressSet = mainStress.sorted(by: { $0.date > $1.date})
+        self.rewardSet = mainReward.sorted(by: { $0.date > $1.date})
+        self.totalSet = createTotalData(stressSet: self.stressSet, rewardSet: self.rewardSet).sorted(by: { $0.date > $1.date})
+    }
+    
+    //데이터 리로드
+    func refreshDatas(){
+        stressSet = mainStress.sorted(by: { $0.date > $1.date})
+        rewardSet = mainReward.sorted(by: { $0.date > $1.date})
+        totalSet = createTotalData(stressSet: self.stressSet, rewardSet: self.rewardSet).sorted(by: { $0.date > $1.date})
+    }
+}
+
+
+
+//@State private var sortedData : Datas
+
+
 struct TimelineView: View {
     @State private var date = Date()
     @State private var showModal = false
-    @State private var selectedView = 2
+    @State private var selectedView = 1
     
     
     //스트레스, 보상 데이터 임시 정의
     
     var date1 = Date()
+    var sortedData = Datas()
     
     
-    struct Datas {
-        let stressSet : [Stress]
-        let rewardSet : [Reward]
-        let totalSet : [Total]
-        
-        //date 기준 내림차순 정렬
-        init(stressSet: [Stress], rewardSet: [Reward]){
-            self.stressSet = stressSet.sorted(by: { $0.date > $1.date})
-            self.rewardSet = rewardSet.sorted(by: { $0.date > $1.date})
-            self.totalSet = createTotalData(stressSet: self.stressSet, rewardSet: self.rewardSet).sorted(by: { $0.date > $1.date})
-        }
-        
-    }
+//    UserDefaults.rewardArray
+//    UserDefaults.stressArray
     
-    var sortedData = Datas(stressSet: UserDefaults.stressArray ?? [], rewardSet: UserDefaults.rewardArray ?? [])
     
     
     var body: some View {
@@ -65,6 +80,9 @@ struct TimelineView: View {
                     Text("보상").tag(3)
                     
                 }
+//                .onChange(of: selectedView, perform: { (value) in
+//                    sortedData.refreshDatas()
+//                })
                 
             }
             .padding([.leading, .trailing])
@@ -120,8 +138,9 @@ struct TimelineView: View {
             
         }
         .navigationBarTitle("타임라인", displayMode: .inline)
-        .navigationBarItems(trailing: Text("hello"))
-        
+        .onAppear {
+            sortedData.refreshDatas()
+        }
     }
     
 }
@@ -249,6 +268,17 @@ func createTotalData(stressSet : [Stress], rewardSet : [Reward]) -> [Total]{
     
     return totalSet
 }
+
+
+//데이터 로드 function
+//func refreshData() -> Datas{
+//    var sortedData : Datas
+//
+//    sortedData = Datas(stressSet: mainStress ?? [], rewardSet: mainReward ?? [])
+//
+//    return sortedData
+//}
+
 
 //여러개의 카테고리가 ","로 구분되어 나열된 string 만들기
 func getStressCateList(stressCategory : [String]) -> String {

--- a/donggle/donggle/Views/TimelineView.swift
+++ b/donggle/donggle/Views/TimelineView.swift
@@ -40,7 +40,7 @@ struct TimelineView: View {
     @State private var date = Date()
     @State private var showModal = false
     @State private var selectedView = 1
-    
+    @Environment(\.presentationMode) var presentation
     
     //스트레스, 보상 데이터 임시 정의
     
@@ -138,8 +138,12 @@ struct TimelineView: View {
             
         }
         .navigationBarTitle("타임라인", displayMode: .inline)
+//        .isDetailLink(false)
         .onAppear {
             sortedData.refreshDatas()
+        }
+        .onDisappear {
+            presentation.wrappedValue.dismiss()
         }
     }
     


### PR DESCRIPTION
https://user-images.githubusercontent.com/67336936/162910024-fd3b731d-2465-48eb-aafb-30de0a083e87.mov

## 작업내용

1. 스트레스, 보상 데이터 등록한 후 타임라인 페이지 들어가면 바로 추가한 데이터 확인할 수 있도록 구현

2. 탭 바 통해 리포트 페이지 방문시 항상 리포트 화면이 먼저 뜨게 구현 (이걸 구현해야 데이터 바로 동기화시킬 수 있어서 같이 구현했어요!)
   _ex) 타임라인 페이지 -> 캘린더 페이지 -> 탭 바에서 리포트 클릭 시 스트레스 보고서 화면 나옴_

4. mainReward, mainStress 데이터 활용하도록 함

##  리뷰포인트
- 변경/리뷰 파일이름
TimelineView 파일
  - 데이터 다시 불러오는 함수 구현
  - onAppear, onDisappear 활용

## 다음으로 진행될 작업

- [ ] 타임라인 페이지 디자인 변경
- [ ] 타임라인 보상 이모티콘(?) 투명도로 완료/미완료 표시
- [ ] 타임라인 보상 카드 누르면 평가하기 모달로

## 질문


## References
* resolved : #67 
