### PR TITLE
#34 [Feat] 캘린더 뷰에서 상세 보기로 연결

### DIFF
--- a/donggle/donggle/Tab bar Views/CalenderView.swift
+++ b/donggle/donggle/Tab bar Views/CalenderView.swift
@@ -104,7 +104,9 @@ struct CalendarView: View {
                                         )
                                     }.padding(10)
                                         .fullScreenCover(isPresented: $isDetailView) {
-                                            DetailView(isFullScreen: $isDetailView, reward : reward)
+                                            
+                                            CardDetailView(reward: reward)
+                                            //DetailView(isFullScreen: $isDetailView, reward : reward)
                                         }
                                     if(reward.isEffective == nil){
                                         rewardCard.foregroundColor(Color.blue)

--- a/donggle/donggle/Views/CardDetailView.swift
+++ b/donggle/donggle/Views/CardDetailView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct CardDetailView: View {
     
+    var reward: Reward
+    
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     @State var showingSheet = false
@@ -46,33 +48,11 @@ struct CardDetailView: View {
         NavigationView{
         ZStack{
             Color(red: 249/255, green: 249/255, blue: 249/255).ignoresSafeArea()
-            /*
-            ZStack{
-                VStack{
-                    HStack{
-                        Image(systemName: "chevron.left")
-                            .padding(.leading, 24)
-                            .padding(.top, 12.0)
-                        Spacer()
-                        Image(systemName: "ellipsis")
-                            .padding(.trailing, 24)
-                            .padding(.top, 12.0)
-                    }
-                    Spacer()
-                }
-                VStack{
-                    Text("보상 상세")
-                        .font(.system(size: 17, weight: .semibold))
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 12.0)
-                    Spacer()
-                }
-            } */
             
             VStack{
                 ZStack{
-                    DetailCardFront(width: width, height: height, degree: $backDegree)
-                    DetailCardBack(width: width, height: height, degree: $frontDegree)
+                    DetailCardFront(width: width, height: height, degree: $backDegree, reward: reward)
+                    DetailCardBack(width: width, height: height, degree: $frontDegree, reward: reward)
 
                 }.onTapGesture{
                     flipCard()
@@ -124,9 +104,10 @@ struct CardDetailView: View {
         }
     }
 }
-
+/*
 struct CardDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        CardDetailView()
+        CardDetailView(reward: reward)
     }
 }
+*/

--- a/donggle/donggle/Views/DetailCard/DetailCardBack.swift
+++ b/donggle/donggle/Views/DetailCard/DetailCardBack.swift
@@ -12,34 +12,57 @@ struct DetailCardBack: View {
     let width: CGFloat
     let height: CGFloat
     @Binding var degree : Double
+    @State var sliderValue : Double = UserDefaults.standard.double(forKey: "sliderValue")
+    @State var stressIndex : Int = UserDefaults.standard.integer(forKey: "stressIndex")
+    var reward: Reward
     
     var body: some View {
-
+         
         ZStack(){
             VStack{
                 Text("2022.04.03")
                     .font(.system(size: 15, weight: .regular))
                     .multilineTextAlignment(.center)
                     .padding(.top, 30.0)
-                Spacer()
-            }
-            VStack{
+                
+                Circle()
+                    .fill(Color.init(red: (sliderValue+1)*2/255, green: (101-sliderValue)*2/255, blue: (101-sliderValue)*2/255))
+                    .frame(width: 100.0, height: 100.0)
+                    .padding(.top, 38)
+                Text("\(stressIndex)%")
+                    .font(.system(size: 15, weight: .regular))
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 5.0)
+                Capsule()
+                    .fill(Color.gray)
+                    .frame(width: 54.0, height: 24.0)
+                
                 Text("아니 왜 갑자기 야근 시켜??? 이거 수요일 마감이잖아요 약속도 취소하고 ㅠㅠ,, 너무 슬프다 저녁에 집가서 야식 먹어야지,, 그래도 오늘은 요정들 드라마볼 수 있어서 버틴다..")
                     .font(.system(size: 17, weight: .regular))
                     .multilineTextAlignment(.center)
-                    .padding(.top, 265.0)
-                    .padding([.leading, .trailing], 30.0)
+                    .padding(.top, 14.0)
+                    .padding([.leading, .trailing], 20.0)
                 Spacer()
             }
         }
         .frame(width: 316.0, height: 418.0)
+        .foregroundColor(Color.black)
         .background(Color.white)
-        .cornerRadius(24)
+        .cornerRadius(20)
         .shadow(color: .black.opacity(0.1), radius: 28, x: 0, y: 12)
         .rotation3DEffect(Angle(degrees: degree), axis: (x:0, y:1, z:0))
         
     }
 }
+/*
+func GetStress(reward: reward){
+    var RStress = UserDefaults.stressArray.filter { stress in reward.stressKey == stress.id}
+     ForEach(RStress) { stress in
+        let content = stress.content
+     }
+}
+*/
+
 /*
 struct DetailCardBack_Previews: PreviewProvider {
     static var previews: some View {

--- a/donggle/donggle/Views/DetailCard/DetailCardFront.swift
+++ b/donggle/donggle/Views/DetailCard/DetailCardFront.swift
@@ -12,34 +12,41 @@ struct DetailCardFront: View {
     let width: CGFloat
     let height: CGFloat
     @Binding var degree : Double
-     
-    var body: some View {
+    var reward: Reward
 
+    var dateFormatText: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYYY.M.d"
+        return formatter
+    }()
+    
+    
+    var body: some View {
+        
         ZStack(){
             VStack{
-                Text("2022.04.03")
+                Text("\(reward.date, formatter: dateFormatText)")
                     .font(.system(size: 15, weight: .regular))
                     .multilineTextAlignment(.center)
                     .padding(.top, 30.0)
                 Spacer()
-            }
-            VStack{
-                Text("야식 뜯어")
+                Text("\(reward.category[0])")
+                Text(reward.title)
                     .font(.system(size: 22, weight: .bold))
                     .multilineTextAlignment(.center)
-                    .padding(.top, 265.0)
-                    .padding(.bottom, 12.0)
-                Text("오늘 도미노 세일 하던데 리버 꼬셔서 같이 먹어야지 우헤헤")
+                    .padding(.top, 29.0)
+                Text(reward.content)
                     .font(.system(size: 17, weight: .regular))
                     .multilineTextAlignment(.center)
+                    .padding(.top, 12.0)
                     .padding([.leading, .trailing], 30.0)
                 Spacer()
-                
             }
+            .foregroundColor(Color.black)
         }
         .frame(width: 316.0, height: 418.0)
         .background(Color.white)
-        .cornerRadius(24)
+        .cornerRadius(20)
         .shadow(color: .black.opacity(0.1), radius: 28, x: 0, y: 12)
         .rotation3DEffect(Angle(degrees: degree), axis: (x:0, y:1, z:0))
         


### PR DESCRIPTION
## 작업내용
캘린더 뷰에서 건빵의 데이터를 받아와서 디테일 카드 뷰로 연결시켰습니다

##  리뷰포인트
- 변경/리뷰 파일이름

## 다음으로 진행될 작업

- [ ] 보상과 연관된 스트레스 요인 연결 ㅠㅠ 
- [ ] 홈뷰와 연결
